### PR TITLE
Feature/websockets - Working but not finished yet

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,13 +12,16 @@ clap = "2.24.2"
 colored = "^1.5"
 csv = "1.0.0-beta.3"
 hyper = "0.10.13"
+openssl = "0.10.15"
 hyper-native-tls = "0.3.0"
 regex = "0.2.1"
 serde_json = "1.0.2"
 time = "0.1.37"
 yaml-rust = "0.3.5"
-env_logger = "0.6.0"
 
 [dependencies.ws]
 version = "0.7.9"
 features = ["ssl"]
+
+[dev-dependencies]
+env_logger = "0.6.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,3 +17,8 @@ regex = "0.2.1"
 serde_json = "1.0.2"
 time = "0.1.37"
 yaml-rust = "0.3.5"
+env_logger = "0.6.0"
+
+[dependencies.ws]
+version = "0.7.9"
+features = ["ssl"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,10 +18,8 @@ regex = "0.2.1"
 serde_json = "1.0.2"
 time = "0.1.37"
 yaml-rust = "0.3.5"
+env_logger = "0.6.0"
 
 [dependencies.ws]
 version = "0.7.9"
 features = ["ssl"]
-
-[dev-dependencies]
-env_logger = "0.6.0"

--- a/src/actions/mod.rs
+++ b/src/actions/mod.rs
@@ -1,8 +1,10 @@
 mod assign;
 mod request;
+mod ws_message;
 
 pub use self::assign::Assign;
 pub use self::request::Request;
+pub use self::ws_message::WSMessage;
 use config;
 
 use std::fmt;

--- a/src/actions/ws_message.rs
+++ b/src/actions/ws_message.rs
@@ -1,0 +1,109 @@
+use std::collections::HashMap;
+
+use yaml_rust::Yaml;
+use colored::*;
+use serde_json;
+use time;
+
+use ws::{connect, CloseCode};
+
+use interpolator;
+use config;
+
+use actions::{Runnable, Report};
+
+#[derive(Clone)]
+pub struct WSMessage {
+  name: String,
+  url: String,
+  time: f64,
+  data: Option<String>,
+  pub with_item: Option<Yaml>,
+  pub assign: Option<String>,
+}
+
+impl WSMessage {
+  pub fn is_that_you(item: &Yaml) -> bool{
+    item["websocket_message"].as_hash().is_some()
+  }
+
+  pub fn new(item: &Yaml, with_item: Option<Yaml>) -> WSMessage {
+    let reference: Option<&str> = item["assign"].as_str();
+    let data: Option<&str> = item["websocket_message"]["data"].as_str();
+
+    WSMessage {
+      name: item["name"].as_str().unwrap().to_string(),
+      url: item["websocket_message"]["url"].as_str().unwrap().to_string(),
+      time: 0.0,
+      data: data.map(str::to_string),
+      with_item: with_item,
+      assign: reference.map(str::to_string),
+    }
+  }
+
+  fn send_request(&self, context: &mut HashMap<String, Yaml>, responses: &mut HashMap<String, serde_json::Value>, _config: &config::Config) -> (f64) {
+
+    let begin = time::precise_time_s();
+
+    let interpolated_name;
+    let interpolated_url;
+
+    // Resolve the url
+    {
+      let interpolator = interpolator::Interpolator::new(context, responses);
+      interpolated_name = interpolator.resolve(&self.name);
+      interpolated_url = interpolator.resolve(&self.url);
+    }
+
+    let data_clone = match &self.data {
+        Some(data) => &data,
+        None => "",
+    };
+
+    if let Err(error) = connect(interpolated_url.clone(), |out| {
+        // Queue a message to be sent when the WebSocket is open
+        if out.send(data_clone).is_err() {
+            println!("Websocket couldn't queue an initial message.")
+        } else {
+            println!("Client sent message 'Hello WebSocket'. ")
+        }
+
+        // The handler needs to take ownership of out, so we use move
+        move |msg| {
+            // Handle messages received on this connection
+            println!("Client got message '{}'. ", msg);
+
+            // Close the connection
+            out.close(CloseCode::Normal)
+        }
+    }) {
+        // Inform the user of failure
+        println!("Failed to create WebSocket due to: {:?}", error);
+    }
+
+    let duration_ms = (time::precise_time_s() - begin) * 1000.0;
+
+    let status_text = if true {
+      "ok".to_string().red()
+    } else {
+      "not ok".to_string().yellow()
+    };
+
+    println!("{:width$} {} {} {}{}", interpolated_name.green(), interpolated_url.blue().bold(), status_text, duration_ms.round().to_string().cyan(), "ms".cyan(), width=25);
+
+    duration_ms
+  }
+}
+
+impl Runnable for WSMessage {
+  fn execute(&self, context: &mut HashMap<String, Yaml>, responses: &mut HashMap<String, serde_json::Value>, reports: &mut Vec<Report>, config: &config::Config) {
+    if self.with_item.is_some() {
+      context.insert("item".to_string(), self.with_item.clone().unwrap());
+    }
+
+    let duration_ms = self.send_request(context, responses, config);
+
+    reports.push(Report { name: self.name.to_owned(), duration: duration_ms, status: 1u16 });
+  }
+
+}

--- a/src/expandable/include.rs
+++ b/src/expandable/include.rs
@@ -51,6 +51,8 @@ pub fn expand_from_filepath(parent_path: &str, mut list: &mut Vec<Box<(Runnable 
       list.push(Box::new(actions::Assign::new(item, None)));
     } else if actions::Request::is_that_you(item){
       list.push(Box::new(actions::Request::new(item, None)));
+    } else if actions::WSMessage::is_that_you(item){
+      list.push(Box::new(actions::WSMessage::new(item, None)));
     }
   }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -8,6 +8,7 @@ extern crate regex;
 extern crate clap;
 extern crate serde_json;
 extern crate ws;
+#[cfg(debug_assertions)]
 extern crate env_logger;
 
 mod config;

--- a/src/main.rs
+++ b/src/main.rs
@@ -7,6 +7,8 @@ extern crate csv;
 extern crate regex;
 extern crate clap;
 extern crate serde_json;
+extern crate ws;
+extern crate env_logger;
 
 mod config;
 mod interpolator;
@@ -25,6 +27,8 @@ use std::f64;
 use clap::crate_version;
 
 fn main() {
+
+  env_logger::init();
 
   let matches = App::new("drill")
                       .version(crate_version!())

--- a/src/main.rs
+++ b/src/main.rs
@@ -27,7 +27,8 @@ use std::f64;
 use clap::crate_version;
 
 fn main() {
-
+  
+  #[cfg(debug_assertions)]
   env_logger::init();
 
   let matches = App::new("drill")


### PR DESCRIPTION
Hey,

This isn't necessarily a merge-ready pull request, but here's my initial implementation of websocket support. The code itself should be pretty straightforward, though there are a few questions around how to handle return values from websocket messages (which could be a relatively common scenario) and how the syntax should look like in the benchmark file.

Currently I use this for the benchmark definition:

```
threads: 4
base: <url>
iterations: 5

plan:
  - name: Websocket test
    websocket_message:
      url: <url>
      data: '{"something":"1", "something_else": "598ae069b90d683653bb9519"}'
```

This way the same plan can mix both HTTP and WS. e.g. Artillery makes it so that you define an engine for a test scenario that might be either HTTP or WS.

At the moment this code works and I've successfully used it to test our backends (so we've now used Drill against software running in production). I've also cleaned it up from warnings, so it's merge-ready once the format for WS messages is finalized.