### PR TITLE
Allow everything but first character of an identifier to be a number

### DIFF
--- a/src/interpolator.rs
+++ b/src/interpolator.rs
@@ -187,3 +187,32 @@ mod tests {
     interpolator.resolve(&url);
   }
 }
+
+#[test]
+  fn interpolates_numnamed_variables() {
+    let mut context: HashMap<String, Yaml> = HashMap::new();
+    let responses: HashMap<String, Value> = HashMap::new();
+
+    context.insert(String::from("zip5"), Yaml::String(String::from("90210")));
+
+    let interpolator = Interpolator{ context: &context, responses: &responses };
+    let url = String::from("http://example.com/postalcode/{{ zip5 }}/view/{{ zip5 }}");
+    let interpolated = interpolator.resolve(&url);
+
+    assert_eq!(interpolated, "http://example.com/postalcode/90210/view/90210");
+  }
+
+#[test]
+  fn interpolates_bad_numnamed_variable_names() {
+    let mut context: HashMap<String, Yaml> = HashMap::new();
+    let responses: HashMap<String, Value> = HashMap::new();
+
+    context.insert(String::from("5digitzip"), Yaml::String(String::from("90210")));
+
+    let interpolator = Interpolator{ context: &context, responses: &responses };
+    let url = String::from("http://example.com/postalcode/{{ 5digitzip }}/view/{{ 5digitzip }}");
+    let interpolated = interpolator.resolve(&url);
+
+    assert_eq!(interpolated, "http://example.com/postalcode/{{ 5digitzip }}/view/{{ 5digitzip }}");
+  }
+

--- a/src/interpolator.rs
+++ b/src/interpolator.rs
@@ -19,7 +19,7 @@ impl<'a> Interpolator<'a> {
   }
 
   pub fn resolve(&self, url: &String) -> String {
-    let re = Regex::new(r"\{\{ *([a-zA-Z\._]+) *\}\}").unwrap();
+    let re = Regex::new(r"\{\{ *([a-zA-Z\._]+[a-zA-Z\._0-9]*) *\}\}").unwrap();
 
     let result = re.replace_all(url.as_str(), |caps: &Captures| {
       let capture = &caps[1];


### PR DESCRIPTION
Spent a long time trying to figure out why identifiers like {{addr1}} and
{{zip4} wouldn't work.