### PR TITLE
First draft - Allow override of csv quote value

### DIFF
--- a/SYNTAX.md
+++ b/SYNTAX.md
@@ -46,3 +46,12 @@ All those three items can be combined with `name` property to be show in logs.
 - `with_items`: List of items to be interpolated in the given request url.
 - `with_items_from_csv`: Read the given CSV values and go through all of them as items.
 - `assign`: save the response in the thread context to be interpolated later.
+
+#### with_items_from_csv item properties
+
+This item can be specified one of two ways.  First, as a simple string specifying the csv file name.
+
+Second, it can be a hash with the following properties:
+
+ - `file_name`: csv file containing the records to be used as items
+ - `quote_char`: character to use as quote in csv parsing.  Defaults to `"\""`, but can be set to `"\'"`.  If your csv file has quoted strings that contain commas and that causes parse errors, make sure this value is set correctly.

--- a/example/benchmark.yml
+++ b/example/benchmark.yml
@@ -55,6 +55,13 @@ plan:
       url: /api/users/contacts/{{ item.id }}
     with_items_from_csv: ./fixtures/users.csv
 
+  - name: Fetch some users from CSV (alternate syntax)
+    request:
+      url: /api/users/contacts/{{ item.id }}
+    with_items_from_csv: 
+      file_name: ./fixtures/users.csv
+      quote_char: "\'"
+
   - name: Fetch no relative url
     request:
       url: http://localhost:9000/api/users.json

--- a/src/expandable/multi_csv_request.rs
+++ b/src/expandable/multi_csv_request.rs
@@ -11,32 +11,24 @@ pub fn is_that_you(item: &Yaml) -> bool{
 }
 
 pub fn expand(parent_path: &str, item: &Yaml, list: &mut Vec<Box<(Runnable + Sync + Send)>>) {
-  let with_items_from_csv_option = item["with_items_from_csv"].as_str();
-  let mut quote_char : u8 = '\"' as u8;
-  let with_items_path : &str;
+    let (with_items_path, quote_char) =
+        if let Some(with_items_path) = item["with_items_from_csv"].as_str() {
+            (with_items_path, '\"' as u8)
+        } else if let Some(_with_items_hash) = item["with_items_from_csv"].as_hash() {
+            let with_items_path = item["with_items_from_csv"]["file_name"].as_str().expect("Expected a file_name");
+            let quote_char = item["with_items_from_csv"]["quote_char"].as_str().unwrap_or("\"").bytes().nth(0).unwrap();
 
-  if with_items_from_csv_option.is_some() {
-    // handle the single string case
-    with_items_path = with_items_from_csv_option.unwrap();
-  }
-  else if item["with_items_from_csv"].as_hash().is_some() {
-    // handle the hash (file_name and quote_char) case
-    with_items_path = item["with_items_from_csv"]["file_name"].as_str().unwrap();
+            (with_items_path, quote_char)
+        } else {
+            panic!("WAT"); // Impossible case
+        };
 
-    if item["with_items_from_csv"]["quote_char"].as_str().is_some() {
-      quote_char = item["with_items_from_csv"]["quote_char"].as_str().unwrap().bytes().nth(0).unwrap();
+    let with_items_filepath = Path::new(parent_path).with_file_name(with_items_path);
+    let final_path = with_items_filepath.to_str().unwrap();
+
+    let with_items_file = reader::read_csv_file_as_yml(final_path, quote_char);
+
+    for with_item in with_items_file {
+        list.push(Box::new(Request::new(item, Some(with_item))));
     }
-
-  }
-  else { 
-    return
-  }
-  let with_items_filepath = Path::new(parent_path).with_file_name(with_items_path);
-  let final_path = with_items_filepath.to_str().unwrap();
-
-  let with_items_file = reader::read_csv_file_as_yml(final_path, quote_char);
-
-  for with_item in with_items_file {
-    list.push(Box::new(Request::new(item, Some(with_item))));
-  }
 }

--- a/src/expandable/multi_csv_request.rs
+++ b/src/expandable/multi_csv_request.rs
@@ -6,21 +6,37 @@ use reader;
 
 pub fn is_that_you(item: &Yaml) -> bool{
   item["request"].as_hash().is_some() &&
-    item["with_items_from_csv"].as_str().is_some()
+    (item["with_items_from_csv"].as_str().is_some() ||
+    item["with_items_from_csv"].as_hash().is_some())
 }
 
 pub fn expand(parent_path: &str, item: &Yaml, list: &mut Vec<Box<(Runnable + Sync + Send)>>) {
   let with_items_from_csv_option = item["with_items_from_csv"].as_str();
+  let mut quote_char : u8 = '\"' as u8;
+  let with_items_path : &str;
 
   if with_items_from_csv_option.is_some() {
-    let with_items_path = with_items_from_csv_option.unwrap();
-    let with_items_filepath = Path::new(parent_path).with_file_name(with_items_path);
-    let final_path = with_items_filepath.to_str().unwrap();
+    // handle the single string case
+    with_items_path = with_items_from_csv_option.unwrap();
+  }
+  else if item["with_items_from_csv"].as_hash().is_some() {
+    // handle the hash (file_name and quote_char) case
+    with_items_path = item["with_items_from_csv"]["file_name"].as_str().unwrap();
 
-    let with_items_file = reader::read_csv_file_as_yml(final_path);
-
-    for with_item in with_items_file {
-      list.push(Box::new(Request::new(item, Some(with_item))));
+    if item["with_items_from_csv"]["quote_char"].as_str().is_some() {
+      quote_char = item["with_items_from_csv"]["quote_char"].as_str().unwrap().bytes().nth(0).unwrap();
     }
+
+  }
+  else { 
+    return
+  }
+  let with_items_filepath = Path::new(parent_path).with_file_name(with_items_path);
+  let final_path = with_items_filepath.to_str().unwrap();
+
+  let with_items_file = reader::read_csv_file_as_yml(final_path, quote_char);
+
+  for with_item in with_items_file {
+    list.push(Box::new(Request::new(item, Some(with_item))));
   }
 }

--- a/src/reader.rs
+++ b/src/reader.rs
@@ -28,7 +28,7 @@ pub fn read_file(filepath: &str) -> String {
 }
 
 // TODO: Try to split this fn into two
-pub fn read_csv_file_as_yml(filepath: &str) -> yaml_rust::yaml::Array {
+pub fn read_csv_file_as_yml(filepath: &str, quote: u8) -> yaml_rust::yaml::Array {
   // Create a path to the desired file
   let path = Path::new(filepath);
   let display = path.display();
@@ -39,8 +39,10 @@ pub fn read_csv_file_as_yml(filepath: &str) -> yaml_rust::yaml::Array {
     Ok(file) => file,
   };
 
+  //println!("DEBUG: quote_char={}", quote);
   let mut rdr = csv::ReaderBuilder::new()
         .has_headers(true)
+        .quote(quote)
         .from_reader(file);
 
   let mut items = yaml_rust::yaml::Array::new();


### PR DESCRIPTION
In the configuration file, allow new way specify item csv file and override
default csv quote character.  This is necessary for (possibly bad) csv files
that have single-quoted fields that contain commas.