### PR TITLE
with_items_range

### DIFF
--- a/SYNTAX.md
+++ b/SYNTAX.md
@@ -44,6 +44,6 @@ All those three items can be combined with `name` property to be show in logs.
 - `method`: HTTP method in the requests. Valid methods are GET, POST, PUT, PATCH or DELETE. (default: GET)
 - `body`: Request body for methods like POST, PUT or PATCH.
 - `with_items`: List of items to be interpolated in the given request url.
-- `with_items_iter`: Generates items from an iterator from start, step, stop.
+- `with_items_range`: Generates items from an iterator from start, step, stop.
 - `with_items_from_csv`: Read the given CSV values and go through all of them as items.
 - `assign`: save the response in the thread context to be interpolated later.

--- a/SYNTAX.md
+++ b/SYNTAX.md
@@ -44,5 +44,6 @@ All those three items can be combined with `name` property to be show in logs.
 - `method`: HTTP method in the requests. Valid methods are GET, POST, PUT, PATCH or DELETE. (default: GET)
 - `body`: Request body for methods like POST, PUT or PATCH.
 - `with_items`: List of items to be interpolated in the given request url.
+- `with_items_iter`: Generates items from an iterator from start, step, stop.
 - `with_items_from_csv`: Read the given CSV values and go through all of them as items.
 - `assign`: save the response in the thread context to be interpolated later.

--- a/example/benchmark.yml
+++ b/example/benchmark.yml
@@ -50,13 +50,13 @@ plan:
       - { id: 73 }
       - { id: 75 }
 
-  - name: Fetch some users by iter
+  - name: Fetch some users by range
     request:
       url: /api/users/{{ item }}
-    with_items_iter:
+    with_items_range:
       start: 70
       step: 5
-      stop: 76
+      stop: 75
 
   - name: Fetch some users from CSV
     request:

--- a/example/benchmark.yml
+++ b/example/benchmark.yml
@@ -55,8 +55,8 @@ plan:
       url: /api/users/{{ item }}
     with_items_iter:
       start: 70
-      step: 2
-      stop: 75
+      step: 5
+      stop: 76
 
   - name: Fetch some users from CSV
     request:

--- a/example/benchmark.yml
+++ b/example/benchmark.yml
@@ -50,6 +50,14 @@ plan:
       - { id: 73 }
       - { id: 75 }
 
+  - name: Fetch some users by iter
+    request:
+      url: /api/users/{{ item }}
+    with_items_iter:
+      start: 70
+      step: 2
+      stop: 75
+
   - name: Fetch some users from CSV
     request:
       url: /api/users/contacts/{{ item.id }}

--- a/src/expandable/include.rs
+++ b/src/expandable/include.rs
@@ -43,6 +43,8 @@ pub fn expand_from_filepath(parent_path: &str, mut list: &mut Vec<Box<(Runnable 
   for item in items {
     if multi_request::is_that_you(item) {
       multi_request::expand(item, &mut list);
+    } else if multi_iter_request::is_that_you(item) {
+      multi_iter_request::expand(item, &mut list);
     } else if multi_csv_request::is_that_you(item) {
       multi_csv_request::expand(parent_path, item, &mut list);
     } else if include::is_that_you(item) {

--- a/src/expandable/include.rs
+++ b/src/expandable/include.rs
@@ -2,7 +2,7 @@ use std::process;
 use yaml_rust::{YamlLoader, Yaml};
 use std::path::Path;
 
-use expandable::{multi_request, multi_csv_request, include};
+use expandable::{multi_request, multi_csv_request, multi_iter_request, include};
 use actions;
 use actions::Runnable;
 

--- a/src/expandable/mod.rs
+++ b/src/expandable/mod.rs
@@ -2,3 +2,4 @@ pub mod include;
 
 mod multi_request;
 mod multi_csv_request;
+mod multi_iter_request;

--- a/src/expandable/multi_iter_request.rs
+++ b/src/expandable/multi_iter_request.rs
@@ -1,0 +1,37 @@
+use yaml_rust::Yaml;
+
+use actions::{Request, Runnable};
+
+pub fn is_that_you(item: &Yaml) -> bool{
+  item["request"].as_hash().is_some() &&
+  item["with_items_iter"].as_hash().is_some()
+}
+
+pub fn expand(item: &Yaml, list: &mut Vec<Box<(Runnable + Sync + Send)>>) {
+  let with_items_iter_option = item["with_items_iter"].as_hash();
+
+  if with_items_iter_option.is_some() {
+    let with_iter_items = with_items_iter_option.unwrap();
+
+    let mut start = 1i64;
+    let mut step = 1usize;
+    let mut stop = 1i64;
+    let ystart = Yaml::String("start".into());
+    let ystep = Yaml::String("step".into());
+    let ystop = Yaml::String("stop".into());
+    if with_iter_items.contains_key(&ystart) && with_iter_items.get(&ystart).unwrap().as_i64().is_some() {
+      start = with_iter_items.get(&ystart).unwrap().as_i64().unwrap();
+    }
+    if with_iter_items.contains_key(&ystep) && with_iter_items.get(&ystep).unwrap().as_i64().is_some() {
+      step = with_iter_items.get(&ystep).unwrap().as_i64().unwrap() as usize;
+    }
+    if with_iter_items.contains_key(&ystop) && with_iter_items.get(&ystop).unwrap().as_i64().is_some() {
+      stop = with_iter_items.get(&ystop).unwrap().as_i64().unwrap();
+    }
+
+    for i in (start .. stop).step_by(step) {
+      list.push(Box::new(Request::new(item, Some(Yaml::Integer(i)))));
+    }
+
+  }
+}

--- a/src/expandable/multi_iter_request.rs
+++ b/src/expandable/multi_iter_request.rs
@@ -13,24 +13,21 @@ pub fn expand(item: &Yaml, list: &mut Vec<Box<(Runnable + Sync + Send)>>) {
   if with_items_iter_option.is_some() {
     let with_iter_items = with_items_iter_option.unwrap();
 
-    let mut start = 1i64;
     let mut step = 1usize;
     let mut stop = 1i64;
+    let init = Yaml::Integer(1);
     let ystart = Yaml::String("start".into());
     let ystep = Yaml::String("step".into());
     let ystop = Yaml::String("stop".into());
-    if with_iter_items.contains_key(&ystart) && with_iter_items.get(&ystart).unwrap().as_i64().is_some() {
-      start = with_iter_items.get(&ystart).unwrap().as_i64().unwrap();
-    }
-    if with_iter_items.contains_key(&ystep) && with_iter_items.get(&ystep).unwrap().as_i64().is_some() {
-      step = with_iter_items.get(&ystep).unwrap().as_i64().unwrap() as usize;
-    }
-    if with_iter_items.contains_key(&ystop) && with_iter_items.get(&ystop).unwrap().as_i64().is_some() {
-      stop = with_iter_items.get(&ystop).unwrap().as_i64().unwrap();
-    }
+    
+    let start : i64 = with_iter_items.get(&ystart).unwrap_or(&init).as_i64().unwrap_or(1);
+    let step : usize = with_iter_items.get(&ystep).unwrap_or(&init).as_i64().unwrap_or(1) as usize;
+    let stop : i64 = with_iter_items.get(&ystop).unwrap_or(&init).as_i64().unwrap_or(1) + 1; // making stop inclusive
 
-    for i in (start .. stop).step_by(step) {
-      list.push(Box::new(Request::new(item, Some(Yaml::Integer(i)))));
+    if stop > start {
+      for i in (start .. stop).step_by(step) {
+        list.push(Box::new(Request::new(item, Some(Yaml::Integer(i)))));
+      }
     }
 
   }

--- a/src/expandable/multi_iter_request.rs
+++ b/src/expandable/multi_iter_request.rs
@@ -4,17 +4,15 @@ use actions::{Request, Runnable};
 
 pub fn is_that_you(item: &Yaml) -> bool{
   item["request"].as_hash().is_some() &&
-  item["with_items_iter"].as_hash().is_some()
+  item["with_items_range"].as_hash().is_some()
 }
 
 pub fn expand(item: &Yaml, list: &mut Vec<Box<(Runnable + Sync + Send)>>) {
-  let with_items_iter_option = item["with_items_iter"].as_hash();
+  let with_items_range_option = item["with_items_range"].as_hash();
 
-  if with_items_iter_option.is_some() {
-    let with_iter_items = with_items_iter_option.unwrap();
+  if with_items_range_option.is_some() {
+    let with_iter_items = with_items_range_option.unwrap();
 
-    let mut step = 1usize;
-    let mut stop = 1i64;
     let init = Yaml::Integer(1);
     let ystart = Yaml::String("start".into());
     let ystep = Yaml::String("step".into());

--- a/src/expandable/multi_iter_request.rs
+++ b/src/expandable/multi_iter_request.rs
@@ -8,25 +8,21 @@ pub fn is_that_you(item: &Yaml) -> bool{
 }
 
 pub fn expand(item: &Yaml, list: &mut Vec<Box<(Runnable + Sync + Send)>>) {
-  let with_items_range_option = item["with_items_range"].as_hash();
-
-  if with_items_range_option.is_some() {
-    let with_iter_items = with_items_range_option.unwrap();
+  if let Some(with_iter_items) = item["with_items_range"].as_hash() {
 
     let init = Yaml::Integer(1);
     let ystart = Yaml::String("start".into());
     let ystep = Yaml::String("step".into());
     let ystop = Yaml::String("stop".into());
     
-    let start : usize = with_iter_items.get(&ystart).unwrap_or(&init).as_i64().unwrap_or(1);
+    let start : i64 = with_iter_items.get(&ystart).unwrap_or(&init).as_i64().unwrap_or(1);
     let step : usize = with_iter_items.get(&ystep).unwrap_or(&init).as_i64().unwrap_or(1) as usize;
-    let stop : usize = with_iter_items.get(&ystop).unwrap_or(&init).as_i64().unwrap_or(1) + 1; // making stop inclusive
+    let stop : i64 = with_iter_items.get(&ystop).unwrap_or(&init).as_i64().unwrap_or(1) + 1; // making stop inclusive
 
     if stop > start && start > 0 {
       for i in (start .. stop).step_by(step) {
         list.push(Box::new(Request::new(item, Some(Yaml::Integer(i)))));
       }
     }
-
   }
 }

--- a/src/expandable/multi_iter_request.rs
+++ b/src/expandable/multi_iter_request.rs
@@ -18,11 +18,11 @@ pub fn expand(item: &Yaml, list: &mut Vec<Box<(Runnable + Sync + Send)>>) {
     let ystep = Yaml::String("step".into());
     let ystop = Yaml::String("stop".into());
     
-    let start : i64 = with_iter_items.get(&ystart).unwrap_or(&init).as_i64().unwrap_or(1);
+    let start : usize = with_iter_items.get(&ystart).unwrap_or(&init).as_i64().unwrap_or(1);
     let step : usize = with_iter_items.get(&ystep).unwrap_or(&init).as_i64().unwrap_or(1) as usize;
-    let stop : i64 = with_iter_items.get(&ystop).unwrap_or(&init).as_i64().unwrap_or(1) + 1; // making stop inclusive
+    let stop : usize = with_iter_items.get(&ystop).unwrap_or(&init).as_i64().unwrap_or(1) + 1; // making stop inclusive
 
-    if stop > start {
+    if stop > start && start > 0 {
       for i in (start .. stop).step_by(step) {
         list.push(Box::new(Request::new(item, Some(Yaml::Integer(i)))));
       }


### PR DESCRIPTION
Adds a support for a generator of numeric item ids from an iterator. Simply specify `with_items_range:` in the config with numeric values for start, step, stop. Each value is optional and will default to 1.

So, for your example valid options are

```yaml
  - name: Fetch some users by iter
    request:
      url: /api/users/{{ item }}
    with_items_range:
      start: 70
      step: 5
      stop: 76
```

or
```yaml
  - name: Fetch some users by iter
    request:
      url: /api/users/{{ item }}
    with_items_range:
      stop: 3
```