### PR TITLE
Nanoseconds

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,6 +182,7 @@ FLAGS:
     -h, --help       Prints help information
         --no-check-certificate    Disables SSL certification check. (Not recommended)
     -s, --stats      Shows request statistics
+    -q, --quiet      Skips output of individual request statistics
     -V, --version    Prints version information
 
 OPTIONS:

--- a/README.md
+++ b/README.md
@@ -183,6 +183,7 @@ FLAGS:
         --no-check-certificate    Disables SSL certification check. (Not recommended)
     -s, --stats      Shows request statistics
     -q, --quiet      Skips output of individual request statistics
+    -n, --nanosec    Shows statistics in nanoseconds
     -V, --version    Prints version information
 
 OPTIONS:

--- a/src/actions/assign.rs
+++ b/src/actions/assign.rs
@@ -31,7 +31,9 @@ impl Assign {
 
 impl Runnable for Assign {
   fn execute(&self, context: &mut HashMap<String, Yaml>, _responses: &mut HashMap<String, Value>, _reports: &mut Vec<Report>, _config: &config::Config) {
-    println!("{:width$} {}={}", self.name.green(), self.key.cyan().bold(), self.value.magenta(), width=25);
+    if !_config.quiet {
+      println!("{:width$} {}={}", self.name.green(), self.key.cyan().bold(), self.value.magenta(), width=25);
+    }
 
     context.insert(self.key.to_owned(), Yaml::String(self.value.to_owned()));
   }

--- a/src/actions/request.rs
+++ b/src/actions/request.rs
@@ -72,6 +72,14 @@ impl Request {
     }
   }
 
+  fn format_time(tdiff: f64, nanosec: bool) -> String {
+    if nanosec {
+      (1_000_000.0 * tdiff).round().to_string() + "ns"
+    } else {
+      tdiff.round().to_string() + "ms"
+    }
+  }
+
   fn send_request(&self, context: &mut HashMap<String, Yaml>, responses: &mut HashMap<String, serde_json::Value>, config: &config::Config) -> (Response, f64) {
     // Build a TSL connector
     let mut connector_builder = TlsConnector::builder();
@@ -152,7 +160,7 @@ impl Request {
     };
 
     if !config.quiet {
-      println!("{:width$} {} {} {}{}", interpolated_name.green(), interpolated_url.blue().bold(), status_text, duration_ms.round().to_string().cyan(), "ms".cyan(), width=25);
+      println!("{:width$} {} {} {}", interpolated_name.green(), interpolated_url.blue().bold(), status_text, Request::format_time(duration_ms, config.nanosec).cyan(), width=25);
     }
     (response, duration_ms)
   }

--- a/src/actions/request.rs
+++ b/src/actions/request.rs
@@ -151,8 +151,9 @@ impl Request {
       response.status.to_string().yellow()
     };
 
-    println!("{:width$} {} {} {}{}", interpolated_name.green(), interpolated_url.blue().bold(), status_text, duration_ms.round().to_string().cyan(), "ms".cyan(), width=25);
-
+    if !config.quiet {
+      println!("{:width$} {} {} {}{}", interpolated_name.green(), interpolated_url.blue().bold(), status_text, duration_ms.round().to_string().cyan(), "ms".cyan(), width=25);
+    }
     (response, duration_ms)
   }
 }

--- a/src/benchmark.rs
+++ b/src/benchmark.rs
@@ -44,8 +44,8 @@ fn join<S:ToString> (l: Vec<S>, sep: &str) -> String {
                   )
 }
 
-pub fn execute(benchmark_path: &str, report_path_option: Option<&str>, no_check_certificate: bool) -> Result<Vec<Vec<Report>>, Vec<Vec<Report>>> {
-  let config = Arc::new(config::Config::new(benchmark_path, no_check_certificate));
+pub fn execute(benchmark_path: &str, report_path_option: Option<&str>, no_check_certificate: bool, quiet: bool) -> Result<Vec<Vec<Report>>, Vec<Vec<Report>>> {
+  let config = Arc::new(config::Config::new(benchmark_path, no_check_certificate, quiet));
 
   if report_path_option.is_some() {
     println!("{}: {}. Ignoring {} and {} properties...", "Report mode".yellow(), "on".purple(), "threads".yellow(), "iterations".yellow());

--- a/src/benchmark.rs
+++ b/src/benchmark.rs
@@ -44,8 +44,8 @@ fn join<S:ToString> (l: Vec<S>, sep: &str) -> String {
                   )
 }
 
-pub fn execute(benchmark_path: &str, report_path_option: Option<&str>, no_check_certificate: bool, quiet: bool) -> Result<Vec<Vec<Report>>, Vec<Vec<Report>>> {
-  let config = Arc::new(config::Config::new(benchmark_path, no_check_certificate, quiet));
+pub fn execute(benchmark_path: &str, report_path_option: Option<&str>, no_check_certificate: bool, quiet: bool, nanosec: bool) -> Result<Vec<Vec<Report>>, Vec<Vec<Report>>> {
+  let config = Arc::new(config::Config::new(benchmark_path, no_check_certificate, quiet, nanosec));
 
   if report_path_option.is_some() {
     println!("{}: {}. Ignoring {} and {} properties...", "Report mode".yellow(), "on".purple(), "threads".yellow(), "iterations".yellow());

--- a/src/config.rs
+++ b/src/config.rs
@@ -12,10 +12,11 @@ pub struct Config {
   pub iterations: i64,
   pub no_check_certificate: bool,
   pub rampup: i64,
+  pub quiet: bool,
 }
 
 impl Config {
-  pub fn new(path: &str, no_check_certificate: bool) -> Config {
+  pub fn new(path: &str, no_check_certificate: bool, quiet: bool) -> Config {
     let config_file = reader::read_file(path);
 
     let config_docs = YamlLoader::load_from_str(config_file.as_str()).unwrap();
@@ -32,6 +33,7 @@ impl Config {
       iterations: iterations,
       no_check_certificate: no_check_certificate,
       rampup: rampup,
+      quiet: quiet,
     }
   }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -13,10 +13,11 @@ pub struct Config {
   pub no_check_certificate: bool,
   pub rampup: i64,
   pub quiet: bool,
+  pub nanosec: bool,
 }
 
 impl Config {
-  pub fn new(path: &str, no_check_certificate: bool, quiet: bool) -> Config {
+  pub fn new(path: &str, no_check_certificate: bool, quiet: bool, nanosec: bool) -> Config {
     let config_file = reader::read_file(path);
 
     let config_docs = YamlLoader::load_from_str(config_file.as_str()).unwrap();
@@ -34,6 +35,7 @@ impl Config {
       no_check_certificate: no_check_certificate,
       rampup: rampup,
       quiet: quiet,
+      nanosec: nanosec,
     }
   }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -33,9 +33,10 @@ fn main() {
   let compare_path_option = matches.value_of("compare");
   let threshold_option = matches.value_of("threshold");
   let no_check_certificate = matches.is_present("no-check-certificate");
+  let quiet = matches.is_present("quiet");
 
   let begin = time::precise_time_s();
-  let list_reports_result = benchmark::execute(benchmark_file, report_path_option, no_check_certificate);
+  let list_reports_result = benchmark::execute(benchmark_file, report_path_option, no_check_certificate, quiet);
   let duration = time::precise_time_s() - begin;
 
   match list_reports_result {
@@ -86,6 +87,11 @@ fn app_args<'a> () -> clap::ArgMatches<'a> {
     .arg(Arg::with_name("no-check-certificate")
                 .long("no-check-certificate")
                 .help("Disables SSL certification check. (Not recommended)")
+                .takes_value(false))
+    .arg(Arg::with_name("quiet")
+                .short("q")
+                .long("quiet")
+                .help("Disables output")
                 .takes_value(false))
     .get_matches();
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -37,7 +37,7 @@ fn main() {
   let nanosec = matches.is_present("nanosec");
 
   let begin = time::precise_time_s();
-  let list_reports_result = benchmark::execute(benchmark_file, report_path_option, no_check_certificate, quiet);
+  let list_reports_result = benchmark::execute(benchmark_file, report_path_option, no_check_certificate, quiet, nanosec);
   let duration = time::precise_time_s() - begin;
 
   match list_reports_result {

--- a/src/main.rs
+++ b/src/main.rs
@@ -153,12 +153,12 @@ fn show_stats (list_reports: &Vec<Vec<Report>>, stats_option: bool, duration: f6
   for (name, reports) in group_by_name {
     let substats = compute_stats(&reports);
     println!("");
-    println!("{} {} {}", name.green(), "Total requests".yellow(), substats.total_requests.to_string().purple());
-    println!("{} {} {}", name.green(), "Successful requests".yellow(), substats.successful_requests.to_string().purple());
-    println!("{} {} {}", name.green(), "Failed requests".yellow(), substats.failed_requests.to_string().purple());
-    println!("{} {} {}{}", name.green(), "Median time per request".yellow(), substats.median_duration.round().to_string().purple(), "ms".purple());
-    println!("{} {} {}{}", name.green(), "Average time per request".yellow(), substats.mean_duration.round().to_string().purple(), "ms".purple());
-    println!("{} {} {}{}", name.green(), "Sample standard deviation".yellow(), substats.stdev_duration.round().to_string().purple(), "ms".purple());
+    println!("{:width$} {:width2$} {}", name.green(), "Total requests".yellow(), substats.total_requests.to_string().purple(), width=25, width2=25);
+    println!("{:width$} {:width2$} {}", name.green(), "Successful requests".yellow(), substats.successful_requests.to_string().purple(), width=25, width2=25);
+    println!("{:width$} {:width2$} {}", name.green(), "Failed requests".yellow(), substats.failed_requests.to_string().purple(), width=25, width2=25);
+    println!("{:width$} {:width2$} {}{}", name.green(), "Median time per request".yellow(), substats.median_duration.round().to_string().purple(), "ms".purple(), width=25, width2=25);
+    println!("{:width$} {:width2$} {}{}", name.green(), "Average time per request".yellow(), substats.mean_duration.round().to_string().purple(), "ms".purple(), width=25, width2=25);
+    println!("{:width$} {:width2$} {}{}", name.green(), "Sample standard deviation".yellow(), substats.stdev_duration.round().to_string().purple(), "ms".purple(), width=25, width2=25);
   }
 
   // compute global stats
@@ -167,15 +167,15 @@ fn show_stats (list_reports: &Vec<Vec<Report>>, stats_option: bool, duration: f6
   let requests_per_second = global_stats.total_requests as f64 / duration;
 
   println!("");
-  println!("{} {}", "Concurrency Level".yellow(), list_reports.len().to_string().purple());
-  println!("{} {} {}", "Time taken for tests".yellow(), format!("{:.1}", duration).to_string().purple(), "seconds".purple());
-  println!("{} {}", "Total requests".yellow(), global_stats.total_requests.to_string().purple());
-  println!("{} {}", "Successful requests".yellow(), global_stats.successful_requests.to_string().purple());
-  println!("{} {}", "Failed requests".yellow(), global_stats.failed_requests.to_string().purple());
-  println!("{} {}{}", "Median time per request".yellow(), global_stats.median_duration.round().to_string().purple(), "ms".purple());
-  println!("{} {}{}", "Average time per request".yellow(), global_stats.mean_duration.round().to_string().purple(), "ms".purple());
-  println!("{} {}{}", "Sample standard deviation".yellow(), global_stats.stdev_duration.round().to_string().purple(), "ms".purple());
-  println!("{} {} {}", "Requests per second".yellow(), format!("{:.2}", requests_per_second).to_string().purple(), "[#/sec]".purple());
+  println!("{:width2$} {}", "Concurrency Level".yellow(), list_reports.len().to_string().purple(), width2=25);
+  println!("{:width2$} {} {}", "Time taken for tests".yellow(), format!("{:.1}", duration).to_string().purple(), "seconds".purple(), width2=25);
+  println!("{:width2$} {}", "Total requests".yellow(), global_stats.total_requests.to_string().purple(), width2=25);
+  println!("{:width2$} {}", "Successful requests".yellow(), global_stats.successful_requests.to_string().purple(), width2=25);
+  println!("{:width2$} {}", "Failed requests".yellow(), global_stats.failed_requests.to_string().purple(), width2=25);
+  println!("{:width2$} {} {}", "Requests per second".yellow(), format!("{:.2}", requests_per_second).to_string().purple(), "[#/sec]".purple(), width2=25);
+  println!("{:width2$} {}{}", "Median time per request".yellow(), global_stats.median_duration.round().to_string().purple(), "ms".purple(), width2=25);
+  println!("{:width2$} {}{}", "Average time per request".yellow(), global_stats.mean_duration.round().to_string().purple(), "ms".purple(), width2=25);
+  println!("{:width2$} {}{}", "Sample standard deviation".yellow(), global_stats.stdev_duration.round().to_string().purple(), "ms".purple(), width2=25);
 }
 
 fn compare_benchmark (list_reports: &Vec<Vec<Report>>, compare_path_option: Option<&str>, threshold_option: Option<&str>) {

--- a/src/main.rs
+++ b/src/main.rs
@@ -90,73 +90,86 @@ fn app_args<'a> () -> clap::ArgMatches<'a> {
     .get_matches();
 }
 
-fn compute_stats (list_reports: &Vec<Report>) -> (usize, usize, usize, f64) {
+struct DrillStats {
+  total_requests: usize,
+  successful_requests: usize,
+  failed_requests: usize,
+  mean_duration: f64,
+  median_duration: f64,
+  stdev_duration: f64,
+}
+
+fn compute_stats (sub_reports: &Vec<Report>) -> DrillStats {
   let mut group_by_status = HashMap::new();
 
-  for req in list_reports.concat() {
+  for req in sub_reports {
     group_by_status.entry(req.status / 100).or_insert(Vec::new()).push(req);
   }
 
-  let durations = list_reports.concat().iter().map(|r| r.duration).collect::<Vec<f64>>();
-  let mean = durations.iter().fold(0f64, |a, &b| a + b) / durations.len() as f64;
-  let deviations = durations.iter().map(|a| (mean - a).powf(2.0)).collect::<Vec<f64>>();
-  let stdev = (deviations.iter().fold(0f64, |a, &b| a + b) / durations.len() as f64).sqrt();
+  let durations = sub_reports.iter().map(|r| r.duration).collect::<Vec<f64>>();
+  let mean_duration = durations.iter().fold(0f64, |a, &b| a + b) / durations.len() as f64;
+  let deviations = durations.iter().map(|a| (mean_duration - a).powf(2.0)).collect::<Vec<f64>>();
+  let stdev_duration = (deviations.iter().fold(0f64, |a, &b| a + b) / durations.len() as f64).sqrt();
 
   let mut sorted = durations.clone();
   sorted.sort_by(|a, b| a.partial_cmp(b).unwrap());
   let durlen = sorted.len();
-  let median = if durlen % 2 == 0 {
+  let median_duration = if durlen % 2 == 0 {
     sorted[durlen / 2]
   } else {
     (sorted[durlen / 2] + sorted[durlen / 2 + 1]) / 2f64
   };
 
-  let total_requests = list_reports.concat().len();
+  let total_requests = sub_reports.len();
   let successful_requests = group_by_status.entry(2).or_insert(Vec::new()).len();
   let failed_requests = total_requests - successful_requests;
-  let requests_per_second = total_requests as f64 / duration;
 
-  (total_requests, successful_requests, failed_requests, requests_per_second)
+  DrillStats{
+    total_requests, 
+    successful_requests, 
+    failed_requests,
+    mean_duration,
+    median_duration,
+    stdev_duration
+  }
 }
 
 fn show_stats (list_reports: &Vec<Vec<Report>>, stats_option: bool, duration: f64) {
   if !stats_option { return }
 
-  let mut group_by_status = HashMap::new();
+  let mut group_by_name = HashMap::new();
 
   for req in list_reports.concat() {
-    group_by_status.entry(req.status / 100).or_insert(Vec::new()).push(req);
+    group_by_name.entry(req.name.clone()).or_insert(Vec::new()).push(req);
   }
 
-  let durations = list_reports.concat().iter().map(|r| r.duration).collect::<Vec<f64>>();
-  let mean = durations.iter().fold(0f64, |a, &b| a + b) / durations.len() as f64;
-  let deviations = durations.iter().map(|a| (mean - a).powf(2.0)).collect::<Vec<f64>>();
-  let stdev = (deviations.iter().fold(0f64, |a, &b| a + b) / durations.len() as f64).sqrt();
+  // compute stats per name
+  for (name, reports) in group_by_name {
+    let substats = compute_stats(&reports);
+    println!("");
+    println!("{} {} {}", name.green(), "Total requests".yellow(), substats.total_requests.to_string().purple());
+    println!("{} {} {}", name.green(), "Successful requests".yellow(), substats.successful_requests.to_string().purple());
+    println!("{} {} {}", name.green(), "Failed requests".yellow(), substats.failed_requests.to_string().purple());
+    println!("{} {} {}{}", name.green(), "Median time per request".yellow(), substats.median_duration.round().to_string().purple(), "ms".purple());
+    println!("{} {} {}{}", name.green(), "Average time per request".yellow(), substats.mean_duration.round().to_string().purple(), "ms".purple());
+    println!("{} {} {}{}", name.green(), "Sample standard deviation".yellow(), substats.stdev_duration.round().to_string().purple(), "ms".purple());
+  }
 
-  let mut sorted = durations.clone();
-  sorted.sort_by(|a, b| a.partial_cmp(b).unwrap());
-  let durlen = sorted.len();
-  let median = if durlen % 2 == 0 {
-    sorted[durlen / 2]
-  } else {
-    (sorted[durlen / 2] + sorted[durlen / 2 + 1]) / 2f64
-  };
-
-  let total_requests = list_reports.concat().len();
-  let successful_requests = group_by_status.entry(2).or_insert(Vec::new()).len();
-  let failed_requests = total_requests - successful_requests;
-  let requests_per_second = total_requests as f64 / duration;
+  // compute global stats
+  let allreports = list_reports.concat();
+  let global_stats = compute_stats(&allreports);
+  let requests_per_second = global_stats.total_requests as f64 / duration;
 
   println!("");
   println!("{} {}", "Concurrency Level".yellow(), list_reports.len().to_string().purple());
   println!("{} {} {}", "Time taken for tests".yellow(), format!("{:.1}", duration).to_string().purple(), "seconds".purple());
-  println!("{} {}", "Total requests".yellow(), total_requests.to_string().purple());
-  println!("{} {}", "Successful requests".yellow(), successful_requests.to_string().purple());
-  println!("{} {}", "Failed requests".yellow(), failed_requests.to_string().purple());
+  println!("{} {}", "Total requests".yellow(), global_stats.total_requests.to_string().purple());
+  println!("{} {}", "Successful requests".yellow(), global_stats.successful_requests.to_string().purple());
+  println!("{} {}", "Failed requests".yellow(), global_stats.failed_requests.to_string().purple());
+  println!("{} {}{}", "Median time per request".yellow(), global_stats.median_duration.round().to_string().purple(), "ms".purple());
+  println!("{} {}{}", "Average time per request".yellow(), global_stats.mean_duration.round().to_string().purple(), "ms".purple());
+  println!("{} {}{}", "Sample standard deviation".yellow(), global_stats.stdev_duration.round().to_string().purple(), "ms".purple());
   println!("{} {} {}", "Requests per second".yellow(), format!("{:.2}", requests_per_second).to_string().purple(), "[#/sec]".purple());
-  println!("{} {}{}", "Median time per request".yellow(), median.round().to_string().purple(), "ms".purple());
-  println!("{} {}{}", "Average time per request".yellow(), mean.round().to_string().purple(), "ms".purple());
-  println!("{} {}{}", "Sample standard deviation".yellow(), stdev.round().to_string().purple(), "ms".purple());
 }
 
 fn compare_benchmark (list_reports: &Vec<Vec<Report>>, compare_path_option: Option<&str>, threshold_option: Option<&str>) {


### PR DESCRIPTION
Shows duration in summary stats in nanoseconds for those who want to squeeze know it. Running benchmark against the testserver with `-sqn` yields:

```
Threads 20
Iterations 3
Rampup 2
Base URL http://localhost:9000


Fetch organizations       Total requests            60
Fetch organizations       Successful requests       60
Fetch organizations       Failed requests           0
Fetch organizations       Median time per request   119034191ns
Fetch organizations       Average time per request  119306601ns
Fetch organizations       Sample standard deviation 7650892ns

...

Fetch sub comments        Total requests            60
Fetch sub comments        Successful requests       0
Fetch sub comments        Failed requests           60
Fetch sub comments        Median time per request   117718216ns
Fetch sub comments        Average time per request  120675522ns
Fetch sub comments        Sample standard deviation 11199586ns

Concurrency Level         20
Time taken for tests      5.9 seconds
Total requests            1020
Successful requests       900
Failed requests           120
Requests per second       174.20 [#/sec]
Median time per request   116521979ns
Average time per request  112444793ns
Sample standard deviation 25777580ns
```