### PR TITLE
Return 520 on bad connection

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Drill
 
-![](http://meritbadge.herokuapp.com/drill)](https://crates.io/crates/drill)
+[![](http://meritbadge.herokuapp.com/drill)](https://crates.io/crates/drill)
 ![](https://travis-ci.com/fcsonline/drill.svg?branch=master)
 
 Drill is a HTTP load testing application written in Rust. The main goal

--- a/src/actions/request.rs
+++ b/src/actions/request.rs
@@ -80,6 +80,7 @@ impl Request {
     }
   }
 
+
   fn send_request(&self, context: &mut HashMap<String, Yaml>, responses: &mut HashMap<String, serde_json::Value>, config: &config::Config) -> (Option<Response>, f64) {
     // Build a TSL connector
     let mut connector_builder = TlsConnector::builder();
@@ -167,6 +168,8 @@ impl Request {
         (Some(response), duration_ms)
       }
     }
+  }
+}
 
 impl Runnable for Request {
   fn execute(&self, context: &mut HashMap<String, Yaml>, responses: &mut HashMap<String, serde_json::Value>, reports: &mut Vec<Report>, config: &config::Config) {


### PR DESCRIPTION
Increases robustness on connection refused errors, which may occur in overload scenarios. At the moment this results in a panic fail of the whole bench. With this change it will be converted to a 520 error and the bench continues.