### PR TITLE
Improve general performance

### DIFF
--- a/example/throughput.yml
+++ b/example/throughput.yml
@@ -1,0 +1,10 @@
+---
+
+threads: 1
+base: 'http://localhost:9000'
+iterations: 10000
+
+plan:
+  - name: Fetch users
+    request:
+      url: /api/users.json


### PR DESCRIPTION
I fixed two small performance issues:

- Avoid interpolator if there are no interpolations
- Avoid SSL initialization if is not `htttps`

Other:

- Extracted relative path resolver from interpolator
