### PR TITLE
Relaxed interpolations

### DIFF
--- a/README.md
+++ b/README.md
@@ -194,6 +194,7 @@ USAGE:
 FLAGS:
     -h, --help       Prints help information
         --no-check-certificate    Disables SSL certification check. (Not recommended)
+        --relaxed-interpolations    Do not panic if an interpolation is not present. (Not recommended)
     -s, --stats      Shows request statistics
     -q, --quiet      Skips output of individual request statistics
     -n, --nanosec    Shows statistics in nanoseconds

--- a/src/actions/request.rs
+++ b/src/actions/request.rs
@@ -91,14 +91,14 @@ impl Request {
 
     // Resolve the name
     let interpolated_name = if self.name.contains('{') {
-      uninterpolator.get_or_insert(interpolator::Interpolator::new(context, responses)).resolve(&self.name)
+      uninterpolator.get_or_insert(interpolator::Interpolator::new(context, responses)).resolve(&self.name, !config.relaxed_interpolations)
     } else {
       self.name.clone()
     };
 
     // Resolve the url
     let interpolated_url = if self.url.contains('{') {
-      uninterpolator.get_or_insert(interpolator::Interpolator::new(context, responses)).resolve(&self.url)
+      uninterpolator.get_or_insert(interpolator::Interpolator::new(context, responses)).resolve(&self.url, !config.relaxed_interpolations)
     } else {
       self.url.clone()
     };
@@ -149,7 +149,7 @@ impl Request {
 
     // Resolve the body
     let request = if let Some(body) = self.body.as_ref() {
-      interpolated_body = uninterpolator.get_or_insert(interpolator::Interpolator::new(context, responses)).resolve(body);
+      interpolated_body = uninterpolator.get_or_insert(interpolator::Interpolator::new(context, responses)).resolve(body, !config.relaxed_interpolations);
 
       client.request(method, interpolated_base_url.as_str()).body(&interpolated_body)
     } else {
@@ -166,7 +166,7 @@ impl Request {
 
     // Resolve headers
     for (key, val) in self.headers.iter() {
-      let interpolated_header = uninterpolator.get_or_insert(interpolator::Interpolator::new(context, responses)).resolve(val);
+      let interpolated_header = uninterpolator.get_or_insert(interpolator::Interpolator::new(context, responses)).resolve(val, !config.relaxed_interpolations);
 
       headers.set_raw(key.to_owned(), vec![interpolated_header.clone().into_bytes()]);
     }

--- a/src/benchmark.rs
+++ b/src/benchmark.rs
@@ -44,8 +44,8 @@ fn join<S: ToString>(l: Vec<S>, sep: &str) -> String {
                   )
 }
 
-pub fn execute(benchmark_path: &str, report_path_option: Option<&str>, no_check_certificate: bool, quiet: bool, nanosec: bool) -> Result<Vec<Vec<Report>>, Vec<Vec<Report>>> {
-  let config = Arc::new(config::Config::new(benchmark_path, no_check_certificate, quiet, nanosec));
+pub fn execute(benchmark_path: &str, report_path_option: Option<&str>, relaxed_interpolations: bool, no_check_certificate: bool, quiet: bool, nanosec: bool) -> Result<Vec<Vec<Report>>, Vec<Vec<Report>>> {
+  let config = Arc::new(config::Config::new(benchmark_path, relaxed_interpolations, no_check_certificate, quiet, nanosec));
 
   if report_path_option.is_some() {
     println!("{}: {}. Ignoring {} and {} properties...", "Report mode".yellow(), "on".purple(), "threads".yellow(), "iterations".yellow());

--- a/src/config.rs
+++ b/src/config.rs
@@ -10,6 +10,7 @@ pub struct Config {
   pub base: String,
   pub threads: i64,
   pub iterations: i64,
+  pub relaxed_interpolations: bool,
   pub no_check_certificate: bool,
   pub rampup: i64,
   pub quiet: bool,
@@ -17,7 +18,7 @@ pub struct Config {
 }
 
 impl Config {
-  pub fn new(path: &str, no_check_certificate: bool, quiet: bool, nanosec: bool) -> Config {
+  pub fn new(path: &str, relaxed_interpolations: bool, no_check_certificate: bool, quiet: bool, nanosec: bool) -> Config {
     let config_file = reader::read_file(path);
 
     let config_docs = YamlLoader::load_from_str(config_file.as_str()).unwrap();
@@ -32,6 +33,7 @@ impl Config {
       base,
       threads,
       iterations,
+      relaxed_interpolations,
       no_check_certificate,
       rampup,
       quiet,

--- a/src/expandable/multi_csv_request.rs
+++ b/src/expandable/multi_csv_request.rs
@@ -40,7 +40,7 @@ mod tests {
     let text = "---\nname: foobar\nrequest:\n  url: /api/{{ item.id }}\nwith_items_from_csv: example/fixtures/users.csv";
     let docs = yaml_rust::YamlLoader::load_from_str(text).unwrap();
     let doc = &docs[0];
-    let mut list: Vec<Box<(Runnable + Sync + Send)>> = Vec::new();
+    let mut list: Vec<Box<(dyn Runnable + Sync + Send)>> = Vec::new();
 
     expand("./", &doc, &mut list);
 

--- a/src/expandable/multi_iter_request.rs
+++ b/src/expandable/multi_iter_request.rs
@@ -35,7 +35,7 @@ mod tests {
     let text = "---\nname: foobar\nrequest:\n  url: /api/{{ item }}\nwith_items_range:\n  start: 2\n  step: 2\n  stop: 20";
     let docs = yaml_rust::YamlLoader::load_from_str(text).unwrap();
     let doc = &docs[0];
-    let mut list: Vec<Box<(Runnable + Sync + Send)>> = Vec::new();
+    let mut list: Vec<Box<(dyn Runnable + Sync + Send)>> = Vec::new();
 
     expand(&doc, &mut list);
 

--- a/src/expandable/multi_request.rs
+++ b/src/expandable/multi_request.rs
@@ -24,7 +24,7 @@ mod tests {
     let text = "---\nname: foobar\nrequest:\n  url: /api/{{ item }}\nwith_items:\n  - 1\n  - 2\n  - 3";
     let docs = yaml_rust::YamlLoader::load_from_str(text).unwrap();
     let doc = &docs[0];
-    let mut list: Vec<Box<(Runnable + Sync + Send)>> = Vec::new();
+    let mut list: Vec<Box<(dyn Runnable + Sync + Send)>> = Vec::new();
 
     expand(&doc, &mut list);
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -33,11 +33,12 @@ fn main() {
   let compare_path_option = matches.value_of("compare");
   let threshold_option = matches.value_of("threshold");
   let no_check_certificate = matches.is_present("no-check-certificate");
+  let relaxed_interpolations = matches.is_present("relaxed-interpolations");
   let quiet = matches.is_present("quiet");
   let nanosec = matches.is_present("nanosec");
 
   let begin = time::precise_time_s();
-  let list_reports_result = benchmark::execute(benchmark_file, report_path_option, no_check_certificate, quiet, nanosec);
+  let list_reports_result = benchmark::execute(benchmark_file, report_path_option, relaxed_interpolations, no_check_certificate, quiet, nanosec);
   let duration = time::precise_time_s() - begin;
 
   match list_reports_result {
@@ -60,6 +61,7 @@ fn app_args<'a>() -> clap::ArgMatches<'a> {
     .arg(Arg::with_name("report").short("r").long("report").help("Sets a report file").takes_value(true).conflicts_with("compare"))
     .arg(Arg::with_name("compare").short("c").long("compare").help("Sets a compare file").takes_value(true).conflicts_with("report"))
     .arg(Arg::with_name("threshold").short("t").long("threshold").help("Sets a threshold value in ms amongst the compared file").takes_value(true).conflicts_with("report"))
+    .arg(Arg::with_name("relaxed-interpolations").long("relaxed-interpolations").help("Do not panic if an interpolation is not present. (Not recommended)").takes_value(false))
     .arg(Arg::with_name("no-check-certificate").long("no-check-certificate").help("Disables SSL certification check. (Not recommended)").takes_value(false))
     .arg(Arg::with_name("quiet").short("q").long("quiet").help("Disables output").takes_value(false))
     .arg(Arg::with_name("nanosec").short("n").long("nanosec").help("Shows statistics in nanoseconds").takes_value(false))


### PR DESCRIPTION
After this https://github.com/fcsonline/drill/pull/41 we removed a panic when an interpolation didn't exist.  After rethinking the behavior about missing interpolations and I'm not sure about defaulting to empty string if previous requests failed. It can induce a wrong URL construction with an unexpected result.

This PR adds a new command flag called `relaxed-interpolations` to be opt-in for this behavior.