### PR TITLE
Add Keep Alive functionality

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -203,6 +203,7 @@ dependencies = [
  "reqwest 0.10.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.53 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio 0.2.20 (registry+https://github.com/rust-lang/crates.io-index)",
+ "url 2.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "yaml-rust 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,7 @@ csv = "1.0.5"
 regex = "1.1.2"
 serde_json = "1.0.39"
 yaml-rust = "0.4.3"
+url = "2.1.1"
 linked-hash-map = "0.5.2"
 tokio = { version = "0.2.20", features = ["rt-core", "rt-threaded", "time", "net", "io-driver"] }
 reqwest = { version = "0.10.4", features = ["cookies", "trust-dns"] }

--- a/example/server/server.js
+++ b/example/server/server.js
@@ -7,6 +7,7 @@ const session = require('express-session');
 
 const app = express();
 const delay = process.env.DELAY_MS || 0;
+const output = process.env.OUTPUT;
 
 app.use(bodyParser.json())
 app.use(bodyParser.urlencoded({ extended: true }))
@@ -23,7 +24,9 @@ const logger_handler = (character) => {
     setTimeout(() => {
       const filename = path.join(__dirname, 'responses', req.path)
       fs.readFile(filename, 'utf8', function(err, data) {
-        process.stdout.write(character);
+        if (output) {
+          process.stdout.write(character);
+        }
 
         if (err) {
           res.status(404);

--- a/example/throughput.yml
+++ b/example/throughput.yml
@@ -1,8 +1,8 @@
 ---
 
-threads: 1
+threads: 10
 base: 'http://localhost:9000'
-iterations: 10000
+iterations: 1000
 
 plan:
   - name: Fetch users

--- a/src/actions/assign.rs
+++ b/src/actions/assign.rs
@@ -2,6 +2,7 @@ use std::collections::HashMap;
 
 use async_trait::async_trait;
 use colored::*;
+use reqwest::Client;
 use serde_json::Value;
 use yaml_rust::Yaml;
 
@@ -32,7 +33,7 @@ impl Assign {
 
 #[async_trait]
 impl Runnable for Assign {
-  async fn execute(&self, context: &mut HashMap<String, Yaml>, _responses: &mut HashMap<String, Value>, _reports: &mut Vec<Report>, _config: &config::Config) {
+  async fn execute(&self, context: &mut HashMap<String, Yaml>, _responses: &mut HashMap<String, Value>, _reports: &mut Vec<Report>, _pool: &mut HashMap<String, Client>, _config: &config::Config) {
     if !_config.quiet {
       println!("{:width$} {}={}", self.name.green(), self.key.cyan().bold(), self.value.magenta(), width = 25);
     }

--- a/src/actions/mod.rs
+++ b/src/actions/mod.rs
@@ -7,6 +7,7 @@ pub use self::assign::Assign;
 pub use self::request::Request;
 use crate::config;
 
+use reqwest::Client;
 use std::collections::HashMap;
 use std::fmt;
 
@@ -15,7 +16,7 @@ use yaml_rust::Yaml;
 
 #[async_trait]
 pub trait Runnable {
-  async fn execute(&self, context: &mut HashMap<String, Yaml>, responses: &mut HashMap<String, Value>, reports: &mut Vec<Report>, config: &config::Config);
+  async fn execute(&self, context: &mut HashMap<String, Yaml>, responses: &mut HashMap<String, Value>, reports: &mut Vec<Report>, pool: &mut HashMap<String, Client>, config: &config::Config);
 }
 
 #[derive(Clone)]


### PR DESCRIPTION
KeepAlive is one of the most interesting features to improve the throughput of `drill`. We will reuse a Client instance per domain to be able to reuse the connection.