### PR TITLE
Add support to headers in assign

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -201,6 +201,7 @@ dependencies = [
  "linked-hash-map 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex 1.3.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "reqwest 0.10.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.110 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.53 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio 0.2.20 (registry+https://github.com/rust-lang/crates.io-index)",
  "url 2.1.1 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,7 @@ clap = "2.32.0"
 colored = "1.7.0"
 csv = "1.0.5"
 regex = "1.1.2"
+serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0.39"
 yaml-rust = "0.4.3"
 url = "2.1.1"

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ plan:
 
   - name: Fetch manager user
     request:
-      url: /api/users/{{ foo.manager_id }}
+      url: /api/users/{{ foo.body.manager_id }}
 
   - name: Assign values
     assign:
@@ -111,7 +111,7 @@ plan:
 
   - name: Fetch endpoint
     request:
-      url: /?counter={{ memory.counter }}
+      url: /?counter={{ memory.body.counter }}
 
   - name: Reset counter
     request:
@@ -124,6 +124,7 @@ plan:
       headers:
         Authorization: Basic aHR0cHdhdGNoOmY=
         X-Foo: Bar
+        X-Bar: Bar {{ memory.headers.token }}
 ```
 
 As you can see, you can play with interpolations in different ways. This

--- a/example/benchmark.yml
+++ b/example/benchmark.yml
@@ -24,15 +24,15 @@ plan:
 
   - name: Fetch manager user
     request:
-      url: /api/users/{{ foo.manager_id }}
+      url: /api/users/{{ foo.body.manager_id }}
 
   - name: Fetch string token
     request:
-      url: /api/tokens/{{ foo.token }}
+      url: /api/tokens/{{ foo.body.token }}
 
   - name: Fetch manager location
     request:
-      url: /api/users/at/{{ foo.address.floor }}/{{ foo.address.room }}
+      url: /api/users/at/{{ foo.body.address.floor }}/{{ foo.body.address.room }}
 
   - name: Assign values
     assign:

--- a/src/interpolator.rs
+++ b/src/interpolator.rs
@@ -16,7 +16,7 @@ impl<'a> Interpolator<'a> {
     Interpolator {
       context,
       responses,
-      regexp: Regex::new(r"\{\{ *([a-zA-Z\._]+[a-zA-Z\._0-9]*) *\}\}").unwrap(),
+      regexp: Regex::new(r"\{\{ *([a-zA-Z\-\._]+[a-zA-Z\-\._0-9]*) *\}\}").unwrap(),
     }
   }
 
@@ -91,12 +91,13 @@ mod tests {
     let responses: HashMap<String, Value> = HashMap::new();
 
     context.insert(String::from("user_Id"), Yaml::String(String::from("12")));
+    context.insert(String::from("Transfer-Encoding"), Yaml::String(String::from("chunked")));
 
     let interpolator = Interpolator::new(&context, &responses);
-    let url = String::from("http://example.com/users/{{ user_Id }}/view/{{ user_Id }}");
+    let url = String::from("http://example.com/users/{{ user_Id }}/view/{{ user_Id }}/{{ Transfer-Encoding }}");
     let interpolated = interpolator.resolve(&url, true);
 
-    assert_eq!(interpolated, "http://example.com/users/12/view/12");
+    assert_eq!(interpolated, "http://example.com/users/12/view/12/chunked");
   }
 
   #[test]


### PR DESCRIPTION
Some users like @mario-s in issue #50 want to have access to headers from previous requests to be able to propagate them in the next ones. Right now we only store the body of the requests.

This PR adds this functionality. It breaks compatibility with the previous syntax but I think the change worth it.

This is syntax has changed in terms of how to access body content:

```yaml
---

threads: 1
base: 'http://localhost:3000'
iterations: 1

plan:
  - name: Fetch account headers
    request:
      url: /api/account
    assign: foo

  - name: Dynamic Custom headers
    request:
      url: /api/messages
      headers:
        X-Foo: Bar {{ foo.account_id }}
```

Now it will be like this:

```yaml
  - name: Dynamic Custom headers
    request:
      url: /api/messages
      headers:
        X-Foo: Bar {{ foo.headers.token }}
        X-Bar: Bar {{ foo.body.account_id }}
```
