### PR TITLE
Handle better misconfiguration

### DIFF
--- a/src/actions/assign.rs
+++ b/src/actions/assign.rs
@@ -3,6 +3,7 @@ use colored::*;
 use serde_json::json;
 use yaml_rust::Yaml;
 
+use crate::actions::extract;
 use crate::actions::Runnable;
 use crate::benchmark::{Context, Pool, Reports};
 use crate::config::Config;
@@ -20,10 +21,14 @@ impl Assign {
   }
 
   pub fn new(item: &Yaml, _with_item: Option<Yaml>) -> Assign {
+    let name = extract(item, "name");
+    let key = extract(&item["assign"], "key");
+    let value = extract(&item["assign"], "value");
+
     Assign {
-      name: item["name"].as_str().unwrap().to_string(),
-      key: item["assign"]["key"].as_str().unwrap().to_string(),
-      value: item["assign"]["value"].as_str().unwrap().to_string(),
+      name: name.to_string(),
+      key: key.to_string(),
+      value: value.to_string(),
     }
   }
 }

--- a/src/actions/delay.rs
+++ b/src/actions/delay.rs
@@ -3,6 +3,7 @@ use colored::*;
 use tokio::time::delay_for;
 use yaml_rust::Yaml;
 
+use crate::actions::extract;
 use crate::actions::Runnable;
 use crate::benchmark::{Context, Pool, Reports};
 use crate::config::Config;
@@ -22,10 +23,11 @@ impl Delay {
   }
 
   pub fn new(item: &Yaml, _with_item: Option<Yaml>) -> Delay {
+    let name = extract(item, "name");
     let seconds = u64::try_from(item["delay"]["seconds"].as_i64().unwrap()).expect("Invalid number of seconds");
 
     Delay {
-      name: item["name"].as_str().unwrap().to_string(),
+      name: name.to_string(),
       seconds,
     }
   }

--- a/src/actions/mod.rs
+++ b/src/actions/mod.rs
@@ -1,4 +1,5 @@
 use async_trait::async_trait;
+use yaml_rust::Yaml;
 
 mod assign;
 mod delay;
@@ -34,5 +35,29 @@ impl fmt::Debug for Report {
 impl fmt::Display for Report {
   fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
     write!(f, "\n- name: {}\n  duration: {}\n  status: {}\n", self.name, self.duration, self.status)
+  }
+}
+
+pub fn extract_optional<'a>(item: &'a Yaml, attr: &'a str) -> Option<&'a str> {
+  if let Some(s) = item[attr].as_str() {
+    Some(s)
+  } else {
+    if item[attr].as_hash().is_some() {
+      panic!("`{}` needs to be a string. Try adding quotes", attr);
+    } else {
+      None
+    }
+  }
+}
+
+pub fn extract<'a>(item: &'a Yaml, attr: &'a str) -> &'a str {
+  if let Some(s) = item[attr].as_str() {
+    s
+  } else {
+    if item[attr].as_hash().is_some() {
+      panic!("`{}` is required needs to be a string. Try adding quotes", attr);
+    } else {
+      panic!("Unknown node `{}` => {:?}", attr, item[attr]);
+    }
   }
 }


### PR DESCRIPTION
Many users have problem trying to setup a benchmark with interpolations.
A common use case is:

```yaml
- name: Fetch user
  request:
    url: {{ memory.body.remote_url }}
```

This is an invalid payload because those curly brackets are valid YAML
syntax for hashes and drill expects a string there. To solve this, the
user needs wrap interpolation with quotes.

This commit improves the shown message when this happens.