### PR TITLE
Preserve the order of groups of requests

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0.39"
 yaml-rust = "0.4.3"
 url = "2.1.1"
-linked-hash-map = "0.5.2"
+linked-hash-map = "0.5.3"
 tokio = { version = "0.2.20", features = ["rt-core", "rt-threaded", "time", "net", "io-driver"] }
 reqwest = { version = "0.10.4", features = ["cookies", "trust-dns"] }
 async-trait = "0.1.30"

--- a/src/main.rs
+++ b/src/main.rs
@@ -11,6 +11,7 @@ use crate::actions::Report;
 use clap::crate_version;
 use clap::{App, Arg};
 use colored::*;
+use linked_hash_map::LinkedHashMap;
 use std::collections::HashMap;
 use std::f64;
 use std::process;
@@ -117,7 +118,7 @@ fn show_stats(list_reports: &[Vec<Report>], stats_option: bool, nanosec: bool, d
     return;
   }
 
-  let mut group_by_name = HashMap::new();
+  let mut group_by_name = LinkedHashMap::new();
 
   for req in list_reports.concat() {
     group_by_name.entry(req.name.clone()).or_insert_with(Vec::new).push(req);


### PR DESCRIPTION
When you ask for request `stats`, the order of requests is not preserved because we do a group of reports. This PR preserves this order for better usability. 