### PR TITLE
Fix building for x86_64-unknown-linux-musl

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -244,6 +244,7 @@ dependencies = [
  "lazy_static",
  "linked-hash-map",
  "num_cpus",
+ "openssl-sys",
  "rand",
  "regex",
  "reqwest",
@@ -826,6 +827,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77af24da69f9d9341038eba93a073b1fdaaa1b788221b00a69bce9e762cb32de"
 
 [[package]]
+name = "openssl-src"
+version = "111.11.0+1.1.1h"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "380fe324132bea01f45239fadfec9343adb044615f29930d039bec1ae7b9fa5b"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "openssl-sys"
 version = "0.9.58"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -834,6 +844,7 @@ dependencies = [
  "autocfg",
  "cc",
  "libc",
+ "openssl-src",
  "pkg-config",
  "vcpkg",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,3 +26,12 @@ futures = "0.3.5"
 lazy_static = "1.4.0"
 num_cpus = "1.13.0"
 rand = "0.7.3"
+
+# Add openssl-sys as a direct dependency so it can be cross compiled to
+# x86_64-unknown-linux-musl using the "vendored" feature below
+openssl-sys = "*"
+
+[features]
+# Force openssl-sys to staticly link in the openssl library. Necessary when
+# cross compiling to x86_64-unknown-linux-musl.
+vendored = ["openssl-sys/vendored"]


### PR DESCRIPTION
This commit add an explicit dependancy to "openssl-sys" and a "vendored
feature to allow cross compilation for x86_64-unknown-linux-musl
platform.

This allow single binary Docker image builds.