### PR TITLE
Avoid interpolations in the bootstrap process

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,14 @@ plan:
       - { id: 73 }
       - { id: 75 }
 
+  - name: Fetch some users by range, index {{ index }}
+    request:
+      url: /api/users/{{ item }}
+    with_items_range:
+      start: 70
+      step: 5
+      stop: 75
+
   - name: Fetch some users from CSV, index {{ index }}
     request:
       url: /api/users/contacts/{{ item.id }}

--- a/src/expandable/multi_iter_request.rs
+++ b/src/expandable/multi_iter_request.rs
@@ -2,6 +2,8 @@ use rand::seq::SliceRandom;
 use rand::thread_rng;
 use yaml_rust::Yaml;
 
+use crate::interpolator::INTERPOLATION_REGEX;
+
 use crate::actions::Request;
 use crate::benchmark::Benchmark;
 
@@ -12,16 +14,38 @@ pub fn is_that_you(item: &Yaml) -> bool {
 pub fn expand(item: &Yaml, benchmark: &mut Benchmark) {
   if let Some(with_iter_items) = item["with_items_range"].as_hash() {
     let init = Yaml::Integer(1);
-    let ystart = Yaml::String("start".into());
-    let ystep = Yaml::String("step".into());
-    let ystop = Yaml::String("stop".into());
+    let lstart = Yaml::String("start".into());
+    let lstep = Yaml::String("step".into());
+    let lstop = Yaml::String("stop".into());
 
-    let start: i64 = with_iter_items.get(&ystart).unwrap_or(&init).as_i64().unwrap_or(1);
-    let step: usize = with_iter_items.get(&ystep).unwrap_or(&init).as_i64().unwrap_or(1) as usize;
-    let stop: i64 = with_iter_items.get(&ystop).unwrap_or(&init).as_i64().unwrap_or(1) + 1; // making stop inclusive
+    let vstart: &Yaml = with_iter_items.get(&lstart).expect("Start property is mandatory");
+    let vstep: &Yaml = with_iter_items.get(&lstep).unwrap_or(&init);
+    let vstop: &Yaml = with_iter_items.get(&lstop).expect("Stop property is mandatory");
+
+    let start: &str = vstart.as_str().unwrap_or("");
+    let step: &str = vstep.as_str().unwrap_or("");
+    let stop: &str = vstop.as_str().unwrap_or("");
+
+    if INTERPOLATION_REGEX.is_match(&start) {
+      panic!("Interpolations not supported in 'start' property!");
+    }
+
+    if INTERPOLATION_REGEX.is_match(&step) {
+      panic!("Interpolations not supported in 'step' property!");
+    }
+
+    if INTERPOLATION_REGEX.is_match(&stop) {
+      panic!("Interpolations not supported in 'stop' property!");
+    }
+
+    let start: i64 = vstart.as_i64().expect("Start needs to be a number");
+    let step: i64 = vstep.as_i64().expect("Step needs to be a number");
+    let stop: i64 = vstop.as_i64().expect("Stop needs to be a number");
+
+    let stop = stop + 1; // making stop inclusive
 
     if stop > start && start > 0 {
-      let mut with_items: Vec<i64> = (start..stop).step_by(step).collect();
+      let mut with_items: Vec<i64> = (start..stop).step_by(step as usize).collect();
 
       if let Some(shuffle) = item["shuffle"].as_bool() {
         if shuffle {
@@ -54,5 +78,27 @@ mod tests {
 
     assert_eq!(is_that_you(&doc), true);
     assert_eq!(benchmark.len(), 10);
+  }
+
+  #[test]
+  #[should_panic]
+  fn invalid_expand() {
+    let text = "---\nname: foobar\nrequest:\n  url: /api/{{ item }}\nwith_items_range:\n  start: 1\n  step: 2\n  stop: foo";
+    let docs = yaml_rust::YamlLoader::load_from_str(text).unwrap();
+    let doc = &docs[0];
+    let mut benchmark: Benchmark = Benchmark::new();
+
+    expand(&doc, &mut benchmark);
+  }
+
+  #[test]
+  #[should_panic]
+  fn runtime_expand() {
+    let text = "---\nname: foobar\nrequest:\n  url: /api/{{ item }}\nwith_items_range:\n  start: 1\n  step: 2\n  stop: \"{{ memory }}\"";
+    let docs = yaml_rust::YamlLoader::load_from_str(text).unwrap();
+    let doc = &docs[0];
+    let mut benchmark: Benchmark = Benchmark::new();
+
+    expand(&doc, &mut benchmark);
   }
 }

--- a/src/interpolator.rs
+++ b/src/interpolator.rs
@@ -8,7 +8,7 @@ static INTERPOLATION_PREFIX: &'static str = "{{";
 static INTERPOLATION_SUFFIX: &'static str = "}}";
 
 lazy_static! {
-  static ref INTERPOLATION_REGEX: Regex = {
+  pub static ref INTERPOLATION_REGEX: Regex = {
     let regexp = format!("{}{}{}", regex::escape(INTERPOLATION_PREFIX), r" *([a-zA-Z\-\._]+[a-zA-Z\-\._0-9]*) *", regex::escape(INTERPOLATION_SUFFIX));
 
     Regex::new(regexp.as_str()).unwrap()


### PR DESCRIPTION
There are some benchmark plan properties that don't support
interpolations because they are used during the plan expansion. They
belong to the bootstrap process and not to the runtime one.

Related https://github.com/fcsonline/drill/issues/94