### PR TITLE
Cargo.toml: remove "readme" field

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,6 @@ version = "0.7.1"
 authors = ["Ferran Basora <fcsonline@gmail.com>"]
 description = "Drill is a HTTP load testing application written in Rust inspired by Ansible syntax"
 repository = "https://github.com/fcsonline/drill"
-readme = "README.md"
 keywords = ["performance", "http", "ansible", "jmeter"]
 license = "GPL-3.0"
 edition = "2018"


### PR DESCRIPTION
It is no more required. See [here](https://doc.rust-lang.org/cargo/reference/manifest.html#the-readme-field).