### PR TITLE
Added command line options to override those in benchmark file. 

### DIFF
--- a/README.md
+++ b/README.md
@@ -217,10 +217,14 @@ FLAGS:
     -V, --version    Prints version information
 
 OPTIONS:
-    -b, --benchmark <benchmark>    Sets the benchmark file
-    -c, --compare <compare>        Sets a compare file
-    -r, --report <report>          Sets a report file
-    -t, --threshold <threshold>    Sets a threshold value in ms amongst the compared file
+    -b, --benchmark <benchmark>        Sets the benchmark file
+    -c, --compare <compare>            Sets a compare file
+    -p, --concurrency <concurrency>    Number of concurrent requests
+    -i, --iterations <iterations>      Total number of requests to perform
+    -e, --rampup <rampup>              Amount of time it takes to reach full concurrency
+    -r, --report <report>              Sets a report file
+    -t, --threshold <threshold>        Sets a threshold value in ms amongst the compared file
+    -u, --url <url>                    Base URL for requests
 
 ```
 

--- a/src/checker.rs
+++ b/src/checker.rs
@@ -7,12 +7,7 @@ use yaml_rust::YamlLoader;
 
 use crate::actions::Report;
 
-pub fn compare(list_reports: &[Vec<Report>], filepath: &str, threshold: &str) -> Result<(), i32> {
-  let threshold_value = match threshold.parse::<f64>() {
-    Ok(v) => v,
-    _ => panic!("arrrgh"),
-  };
-
+pub fn compare(list_reports: &[Vec<Report>], filepath: &str, threshold: f64) -> Result<(), i32> {
   // Create a path to the desired file
   let path = Path::new(filepath);
   let display = path.display();
@@ -41,7 +36,7 @@ pub fn compare(list_reports: &[Vec<Report>], filepath: &str, threshold: &str) ->
       let recorded_duration = items[i]["duration"].as_f64().unwrap();
       let delta_ms = report_item.duration - recorded_duration;
 
-      if delta_ms > threshold_value {
+      if delta_ms > threshold {
         println!("{:width$} is {}{} slower than before", report_item.name.green(), delta_ms.round().to_string().red(), "ms".red(), width = 25);
 
         slow_counter += 1;

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,99 +1,108 @@
+use std::convert::TryFrom;
+
 use yaml_rust::{Yaml, YamlLoader};
 
-use crate::benchmark::Context;
+use crate::benchmark::{BenchmarkOptions, Context};
 use crate::interpolator;
 use crate::reader;
 
-const NITERATIONS: i64 = 1;
-const NRAMPUP: i64 = 0;
+const NCONCURRENCY: usize = 1;
+const NITERATIONS: usize = 1;
+const NRAMPUP: usize = 0;
 
 pub struct Config {
   pub base: String,
-  pub concurrency: i64,
-  pub iterations: i64,
+  pub concurrency: usize,
+  pub iterations: usize,
   pub relaxed_interpolations: bool,
   pub no_check_certificate: bool,
-  pub rampup: i64,
+  pub rampup: usize,
   pub quiet: bool,
   pub nanosec: bool,
 }
 
 impl Config {
-  pub fn new(path: &str, relaxed_interpolations: bool, no_check_certificate: bool, quiet: bool, nanosec: bool) -> Config {
-    let config_file = reader::read_file(path);
+  pub fn new(options: &BenchmarkOptions) -> Config {
+    let mut config = Config {
+      base: "".to_owned(),
+      concurrency: NCONCURRENCY,
+      iterations: NITERATIONS,
+      relaxed_interpolations: options.relaxed_interpolations,
+      no_check_certificate: options.no_check_certificate,
+      rampup: NRAMPUP,
+      quiet: options.quiet,
+      nanosec: options.nanosec,
+    };
+    // load options from benchmark file
+    if options.benchmark_path_option.is_some() {
+      let config_file = reader::read_file(options.benchmark_path_option.unwrap());
 
-    let config_docs = YamlLoader::load_from_str(config_file.as_str()).unwrap();
-    let config_doc = &config_docs[0];
+      let config_docs = YamlLoader::load_from_str(config_file.as_str()).unwrap();
+      let config_doc = &config_docs[0];
 
-    let context: Context = Context::new();
-    let interpolator = interpolator::Interpolator::new(&context);
+      let context: Context = Context::new();
+      let interpolator = interpolator::Interpolator::new(&context);
 
-    let iterations = read_i64_configuration(config_doc, &interpolator, "iterations", NITERATIONS);
-    let concurrency = read_i64_configuration(config_doc, &interpolator, "concurrency", iterations);
-    let rampup = read_i64_configuration(config_doc, &interpolator, "rampup", NRAMPUP);
-    let base = read_str_configuration(config_doc, &interpolator, "base", "");
+      if let Some(value) = read_i64_configuration(config_doc, &interpolator, "iterations") {
+        config.iterations = usize::try_from(value).expect("Expecting a positive integer value for 'iterations' parameter");
+      }
+      if let Some(value) = read_i64_configuration(config_doc, &interpolator, "concurrency") {
+        config.concurrency = usize::try_from(value).expect("Expecting a positive integer value for 'concurrency' parameter");
+      }
+      if let Some(value) = read_i64_configuration(config_doc, &interpolator, "rampup") {
+        config.rampup = usize::try_from(value).expect("Expecting a positive integer value for 'rampup' parameter");
+      }
+      if let Some(value) = read_str_configuration(config_doc, &interpolator, "base") {
+        config.base = value;
+      }
+    }
+    // overwrite defaults and options from benchmark file with those from command line (BenchmarkOptions struct)
+    if let Some(value) = options.base_url_option {
+      config.base = value.to_owned();
+    }
+    if let Some(value) = options.concurrency_option {
+      config.concurrency = value;
+    }
+    if let Some(value) = options.iterations_option {
+      config.iterations = value;
+    }
+    if let Some(value) = options.rampup_option {
+      config.rampup = value;
+    }
 
-    if concurrency > iterations {
+    if config.concurrency > config.iterations {
       panic!("The concurrency can not be higher than the number of iterations")
     }
 
-    Config {
-      base,
-      concurrency,
-      iterations,
-      relaxed_interpolations,
-      no_check_certificate,
-      rampup,
-      quiet,
-      nanosec,
-    }
+    return config;
   }
 }
 
-fn read_str_configuration(config_doc: &Yaml, interpolator: &interpolator::Interpolator, name: &str, default: &str) -> String {
-  match config_doc[name].as_str() {
-    Some(value) => {
-      if value.contains('{') {
-        interpolator.resolve(&value, true).to_owned()
-      } else {
-        value.to_owned()
-      }
+fn read_str_configuration(config_doc: &Yaml, interpolator: &interpolator::Interpolator, name: &str) -> Option<String> {
+  if let Some(value) = config_doc[name].as_str() {
+    if value.contains('{') {
+      Some(interpolator.resolve(&value, true).to_owned())
+    } else {
+      Some(value.to_owned())
     }
-    None => {
-      if config_doc[name].as_str().is_some() {
-        println!("Invalid {} value!", name);
-      }
-
-      default.to_owned()
-    }
+  } else {
+    if config_doc[name].as_str().is_some() {
+      println!("Invalid {} value!", name)
+    };
+    None
   }
 }
 
-fn read_i64_configuration(config_doc: &Yaml, interpolator: &interpolator::Interpolator, name: &str, default: i64) -> i64 {
-  let value = if let Some(value) = config_doc[name].as_i64() {
+// Note: yaml_rust can't parse directly into usize yet, so must be i64 for now
+fn read_i64_configuration(config_doc: &Yaml, interpolator: &interpolator::Interpolator, name: &str) -> Option<i64> {
+  if let Some(value) = config_doc[name].as_i64() {
     Some(value)
   } else if let Some(key) = config_doc[name].as_str() {
-    interpolator.resolve(&key, false).parse::<i64>().ok()
+    Some(interpolator.resolve(&key, false).parse::<i64>().expect(format!("Unable to parse benchmark option '{}' into i64", name).as_str()))
   } else {
+    if config_doc[name].as_str().is_some() {
+      println!("Invalid {} value!", name)
+    };
     None
-  };
-
-  match value {
-    Some(value) => {
-      if value < 0 {
-        println!("Invalid negative {} value!", name);
-
-        default
-      } else {
-        value
-      }
-    }
-    None => {
-      if config_doc[name].as_str().is_some() {
-        println!("Invalid {} value!", name);
-      }
-
-      default
-    }
   }
 }


### PR DESCRIPTION
Let's the user provide the following options on the command line to override those options in the benchmark file:
baseUrl - (no default, must be provided on command line or contained in benchmark file)
concurrency - defaults to 1 if no benchmark file is provided
iterations - defaults to 1 if no benchmark file is provided
rampup - defaults to 0 if no benchmark file is provided.

Note that this makes providing a benchmark file optional.

This commit also changes a few types and function signatures to better protect against bad user input.