### PR TITLE
Assert values

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,11 @@ plan:
       key: bar
       value: "2"
 
+  - name: Assert values
+    assert:
+      key: bar
+      value: "2"
+
   - name: Fetch user from assign
     request:
       url: /api/users/{{ bar }}
@@ -176,10 +181,11 @@ This is the list of all features supported by the current version of `drill`:
 - **Concurrency:** run your benchmarks choosing the number of concurrent iterations.
 - **Multi iterations:** specify the number of iterations you want to run the benchmark.
 - **Ramp-up:** specify the amount of time it will take `drill` to start all iterations.
-- **Delay:** introduce controlled delay between requests. Example: [assigns.yml](./example/delay.yml)
+- **Delay:** introduce controlled delay between requests. Example: [delay.yml](./example/delay.yml)
 - **Dynamic urls:** execute requests with dynamic interpolations in the url, like `/api/users/{{ item }}`
 - **Dynamic headers:** execute requests with dynamic headers. Example: [headers.yml](./example/headers.yml)
 - **Interpolate environment variables:** set environment variables, like `/api/users/{{ EDITOR }}`
+- **Assertions:** assert values during the test plan. Example: [iterations.yml](./example/iterations.yml)
 - **Request dependencies:** create dependencies between requests with `assign` and url interpolations.
 - **Split files:** organize your benchmarks in multiple files and include them.
 - **CSV support:** read CSV files and build N requests fill dynamic interpolations with CSV data.

--- a/example/benchmark.yml
+++ b/example/benchmark.yml
@@ -62,6 +62,11 @@ plan:
       - { id: 73 }
       - { id: 75 }
 
+  - name: Assert values
+    assert:
+      key: bar
+      value: "2"
+
   - name: Fetch some users by range, index {{ index }}
     request:
       url: /api/users/{{ item }}

--- a/example/iterations.yml
+++ b/example/iterations.yml
@@ -21,6 +21,11 @@ plan:
       url: /api/account
     assign: foo
 
+  - name: Assert values
+    assert:
+      key: foo.body.manager_id
+      value: "73"
+
   - name: "Fetch 4 - Iteration: {{ iteration }}"
     request:
       url: /api/users/{{ foo.body.manager_id }}

--- a/src/actions/assert.rs
+++ b/src/actions/assert.rs
@@ -1,0 +1,53 @@
+use async_trait::async_trait;
+use colored::*;
+use serde_json::json;
+use yaml_rust::Yaml;
+
+use crate::actions::extract;
+use crate::actions::Runnable;
+use crate::benchmark::{Context, Pool, Reports};
+use crate::config::Config;
+use crate::interpolator;
+
+#[derive(Clone)]
+pub struct Assert {
+  name: String,
+  key: String,
+  value: String,
+}
+
+impl Assert {
+  pub fn is_that_you(item: &Yaml) -> bool {
+    item["assert"].as_hash().is_some()
+  }
+
+  pub fn new(item: &Yaml, _with_item: Option<Yaml>) -> Assert {
+    let name = extract(item, "name");
+    let key = extract(&item["assert"], "key");
+    let value = extract(&item["assert"], "value");
+
+    Assert {
+      name: name.to_string(),
+      key: key.to_string(),
+      value: value.to_string(),
+    }
+  }
+}
+
+#[async_trait]
+impl Runnable for Assert {
+  async fn execute(&self, context: &mut Context, _reports: &mut Reports, _pool: &Pool, config: &Config) {
+    if !config.quiet {
+      println!("{:width$} {}={}?", self.name.green(), self.key.cyan().bold(), self.value.magenta(), width = 25);
+    }
+
+    let interpolator = interpolator::Interpolator::new(context);
+    let eval = format!("{{{{ {} }}}}", &self.key);
+    let stored = interpolator.resolve(&eval, true);
+    let assertion = json!(self.value.to_owned());
+
+    if *stored != assertion {
+      panic!("Assertion missmatched: {} != {}", stored, assertion);
+    }
+  }
+}

--- a/src/actions/mod.rs
+++ b/src/actions/mod.rs
@@ -1,10 +1,12 @@
 use async_trait::async_trait;
 use yaml_rust::Yaml;
 
+mod assert;
 mod assign;
 mod delay;
 mod request;
 
+pub use self::assert::Assert;
 pub use self::assign::Assign;
 pub use self::delay::Delay;
 pub use self::request::Request;

--- a/src/expandable/include.rs
+++ b/src/expandable/include.rs
@@ -60,6 +60,8 @@ pub fn expand_from_filepath(parent_path: &str, mut benchmark: &mut Benchmark, ac
       benchmark.push(Box::new(actions::Delay::new(item, None)));
     } else if actions::Assign::is_that_you(item) {
       benchmark.push(Box::new(actions::Assign::new(item, None)));
+    } else if actions::Assert::is_that_you(item) {
+      benchmark.push(Box::new(actions::Assert::new(item, None)));
     } else if actions::Request::is_that_you(item) {
       benchmark.push(Box::new(actions::Request::new(item, None, None)));
     } else {


### PR DESCRIPTION
Adding the capability to assert variables during a test plan.

```yml
  - name: Assert values
        assert:
          key: bar
          value: "2"

  - name: Assert values from responses
        assert:
          key: previous_request.body.manager_id
          value: "73"
```