### PR TITLE
Add the capability to execute OS commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,6 +136,11 @@ plan:
       method: DELETE
       url: /
 
+  - name: Exec external commands
+    exec:
+      command: "echo '{{ foo.body }}' | jq .phones[0] | tr -d '\"'"
+    assign: baz
+
   - name: Custom headers
     request:
       url: /admin
@@ -185,6 +190,7 @@ This is the list of all features supported by the current version of `drill`:
 - **Dynamic urls:** execute requests with dynamic interpolations in the url, like `/api/users/{{ item }}`
 - **Dynamic headers:** execute requests with dynamic headers. Example: [headers.yml](./example/headers.yml)
 - **Interpolate environment variables:** set environment variables, like `/api/users/{{ EDITOR }}`
+- **Executions:** execute remote commands with test plan data.
 - **Assertions:** assert values during the test plan. Example: [iterations.yml](./example/iterations.yml)
 - **Request dependencies:** create dependencies between requests with `assign` and url interpolations.
 - **Split files:** organize your benchmarks in multiple files and include them.

--- a/example/benchmark.yml
+++ b/example/benchmark.yml
@@ -41,6 +41,7 @@ plan:
     assign:
       key: bar
       value: "2"
+
   - name: Fetch user from assign
     request:
       url: /api/users/{{ bar }}
@@ -66,6 +67,16 @@ plan:
     assert:
       key: bar
       value: "2"
+
+  - name: Exec external commands
+    exec:
+      command: "echo '{{ foo.body }}' | jq .phones[0] | tr -d '\"'"
+    assign: baz
+
+  - name: Assert external execution
+    assert:
+      key: baz
+      value: "+44 1234567"
 
   - name: Fetch some users by range, index {{ index }}
     request:

--- a/src/actions/assert.rs
+++ b/src/actions/assert.rs
@@ -46,7 +46,7 @@ impl Runnable for Assert {
     let stored = interpolator.resolve(&eval, true);
     let assertion = json!(self.value.to_owned());
 
-    if *stored != assertion {
+    if !stored.eq(&assertion) {
       panic!("Assertion missmatched: {} != {}", stored, assertion);
     }
   }

--- a/src/actions/exec.rs
+++ b/src/actions/exec.rs
@@ -1,0 +1,58 @@
+use async_trait::async_trait;
+use colored::*;
+use serde_json::json;
+use std::process::Command;
+use yaml_rust::Yaml;
+
+use crate::actions::Runnable;
+use crate::actions::{extract, extract_optional};
+use crate::benchmark::{Context, Pool, Reports};
+use crate::config::Config;
+use crate::interpolator;
+
+#[derive(Clone)]
+pub struct Exec {
+  name: String,
+  command: String,
+  pub assign: Option<String>,
+}
+
+impl Exec {
+  pub fn is_that_you(item: &Yaml) -> bool {
+    item["exec"].as_hash().is_some()
+  }
+
+  pub fn new(item: &Yaml, _with_item: Option<Yaml>) -> Exec {
+    let name = extract(item, "name");
+    let command = extract(&item["exec"], "command");
+    let assign = extract_optional(item, "assign");
+
+    Exec {
+      name: name.to_string(),
+      command: command.to_string(),
+      assign: assign.map(str::to_string),
+    }
+  }
+}
+
+#[async_trait]
+impl Runnable for Exec {
+  async fn execute(&self, context: &mut Context, _reports: &mut Reports, _pool: &Pool, config: &Config) {
+    if !config.quiet {
+      println!("{:width$} {}", self.name.green(), self.command.cyan().bold(), width = 25);
+    }
+
+    let final_command = interpolator::Interpolator::new(context).resolve(&self.command, !config.relaxed_interpolations);
+
+    let args = vec!["bash", "-c", "--", final_command.as_str()];
+
+    let execution = Command::new(args[0]).args(&args[1..]).output().expect("Couldn't run it");
+
+    let output: String = String::from_utf8_lossy(&execution.stdout).into();
+    let output = output.trim_end().to_string().to_owned();
+
+    if let Some(ref key) = self.assign {
+      context.insert(key.to_owned(), json!(output));
+    }
+  }
+}

--- a/src/actions/mod.rs
+++ b/src/actions/mod.rs
@@ -4,11 +4,13 @@ use yaml_rust::Yaml;
 mod assert;
 mod assign;
 mod delay;
+mod exec;
 mod request;
 
 pub use self::assert::Assert;
 pub use self::assign::Assign;
 pub use self::delay::Delay;
+pub use self::exec::Exec;
 pub use self::request::Request;
 
 use crate::benchmark::{Context, Pool, Reports};

--- a/src/expandable/include.rs
+++ b/src/expandable/include.rs
@@ -58,6 +58,8 @@ pub fn expand_from_filepath(parent_path: &str, mut benchmark: &mut Benchmark, ac
       include::expand(parent_path, item, &mut benchmark);
     } else if actions::Delay::is_that_you(item) {
       benchmark.push(Box::new(actions::Delay::new(item, None)));
+    } else if actions::Exec::is_that_you(item) {
+      benchmark.push(Box::new(actions::Exec::new(item, None)));
     } else if actions::Assign::is_that_you(item) {
       benchmark.push(Box::new(actions::Assign::new(item, None)));
     } else if actions::Assert::is_that_you(item) {


### PR DESCRIPTION
Trying to cover the common use case of executing OS commands during a test plan, mentioned here: https://github.com/fcsonline/drill/issues/113