### PR TITLE
[README] Add Linux/macOS/Windows specific instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,7 +173,29 @@ cargo build --release
 ./target/release/drill --benchmark benchmark.yml --stats
 ```
 
-**Note:** You will need to install `libssl-dev` and `pkg-config` packages.
+### Dependencies
+
+OpenSSL is needed in order to compile Drill, whether it is through `cargo install`
+or when compiling from source with `cargo build`.
+
+Depending on your platform, the name of the dependencies may differ.
+
+#### Linux
+
+Install `libssl-dev` and `pkg-config` packages with your favorite package manager
+(if `libssl-dev` is not found, try other names like `openssl` or `openssl-devel`).
+
+#### macOS
+
+First, install the [Homebrew](https://brew.sh/) package manager.
+
+And then install `openssl` with Homebrew.
+
+#### Windows
+
+First, install [vcpkg](https://vcpkg.io/en/getting-started.html).
+
+And then run `vcpkg install openssl:x64-windows-static-md`.
 
 ## Demo
 


### PR DESCRIPTION
Hi,

This PR adds a subsection "Dependencies" under the "Install" section in the README to give more details on how to install the dependencies needed to compile Drill.

Most notably the Windows specific instructions on how to install OpenSSL were missing. It is through the error messages of the `openssl-sys` crate's custom build script that I found that Vcpkg was needed along with the package `openssl:x64-windows-static-md`.

Regards 😄 