### PR TITLE
#59 get no_proxy in from reqwest

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -865,9 +865,9 @@ dependencies = [
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.64"
+version = "0.9.66"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "209efc2fe0e980c8849efacdb567f975a1c80245c4f6980d6f012733bfa851af"
+checksum = "1996d2d305e561b70d1ee0c53f1542833f4e1ac6ce9a6708b6ff2738ca67dc82"
 dependencies = [
  "autocfg",
  "cc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,7 @@ rand = "0.7.3"
 
 # Add openssl-sys as a direct dependency so it can be cross compiled to
 # x86_64-unknown-linux-musl using the "vendored" feature below
-openssl-sys = "*"
+openssl-sys = "0.9.66"
 
 [features]
 # Force openssl-sys to staticly link in the openssl library. Necessary when

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ yaml-rust = "0.4.3"
 url = "2.1.1"
 linked-hash-map = "0.5.3"
 tokio = { version = "0.2.20", features = ["rt-core", "rt-threaded", "time", "net", "io-driver"] }
-reqwest = { version = "0.10.4", features = ["cookies", "trust-dns"] }
+reqwest = { version = "0.10.10", features = ["cookies", "trust-dns"] }
 async-trait = "0.1.30"
 futures = "0.3.5"
 lazy_static = "1.4.0"


### PR DESCRIPTION
Reqwest 0.10.10 has system proxy / no_proxy support included. 