### PR TITLE
Add basic proxy support

### DIFF
--- a/README.md
+++ b/README.md
@@ -197,6 +197,7 @@ This is the list of all features supported by the current version of `drill`:
 - **CSV support:** read CSV files and build N requests fill dynamic interpolations with CSV data.
 - **HTTP methods:** build request with different http methods like GET, POST, PUT, PATCH, HEAD or DELETE.
 - **Cookie support:** create benchmarks with sessions because cookies are propagates between requests.
+- **Proxy support:** run benchmarks through proxies.
 - **Stats:** get nice statistics about all the requests. Example: [cookies.yml](./example/cookies.yml)
 - **Thresholds:** compare the current benchmark performance against a stored one session and fail if a threshold is exceeded.
 
@@ -213,7 +214,7 @@ production environments.
 Full list of cli options, which is available under `drill --help`
 
 ```
-drill 0.7.1
+drill 0.7.2
 HTTP load testing application written in Rust inspired by Ansible syntax
 
 USAGE:
@@ -232,6 +233,7 @@ FLAGS:
 OPTIONS:
     -b, --benchmark <benchmark>    Sets the benchmark file
     -c, --compare <compare>        Sets a compare file
+    -p, --proxy <proxy>            [protocol://]host[:port] Use this proxy
     -r, --report <report>          Sets a report file
     -t, --threshold <threshold>    Sets a threshold value in ms amongst the compared file
     -o, --timeout <timeout>        Set timeout in seconds for all requests

--- a/src/benchmark.rs
+++ b/src/benchmark.rs
@@ -53,8 +53,8 @@ fn join<S: ToString>(l: Vec<S>, sep: &str) -> String {
   )
 }
 
-pub fn execute(benchmark_path: &str, report_path_option: Option<&str>, relaxed_interpolations: bool, no_check_certificate: bool, quiet: bool, nanosec: bool, timeout: Option<&str>, verbose: bool) -> BenchmarkResult {
-  let config = Arc::new(Config::new(benchmark_path, relaxed_interpolations, no_check_certificate, quiet, nanosec, timeout.map_or(10, |t| t.parse().unwrap_or(10)), verbose));
+pub fn execute(benchmark_path: &str, report_path_option: Option<&str>, relaxed_interpolations: bool, no_check_certificate: bool, proxy: &str, quiet: bool, nanosec: bool, timeout: Option<&str>, verbose: bool) -> BenchmarkResult {
+  let config = Arc::new(Config::new(benchmark_path, relaxed_interpolations, no_check_certificate, proxy, quiet, nanosec, timeout.map_or(10, |t| t.parse().unwrap_or(10)), verbose));
 
   if report_path_option.is_some() {
     println!("{}: {}. Ignoring {} and {} properties...", "Report mode".yellow(), "on".purple(), "concurrency".yellow(), "iterations".yellow());

--- a/src/config.rs
+++ b/src/config.rs
@@ -18,10 +18,11 @@ pub struct Config {
   pub nanosec: bool,
   pub timeout: u64,
   pub verbose: bool,
+  pub proxy: String,
 }
 
 impl Config {
-  pub fn new(path: &str, relaxed_interpolations: bool, no_check_certificate: bool, quiet: bool, nanosec: bool, timeout: u64, verbose: bool) -> Config {
+  pub fn new(path: &str, relaxed_interpolations: bool, no_check_certificate: bool, proxy: &str, quiet: bool, nanosec: bool, timeout: u64, verbose: bool) -> Config {
     let config_file = reader::read_file(path);
 
     let config_docs = YamlLoader::load_from_str(config_file.as_str()).unwrap();
@@ -50,6 +51,7 @@ impl Config {
       nanosec,
       timeout,
       verbose,
+      proxy: proxy.to_string(),
     }
   }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -25,6 +25,7 @@ fn main() {
   let threshold_option = matches.value_of("threshold");
   let no_check_certificate = matches.is_present("no-check-certificate");
   let relaxed_interpolations = matches.is_present("relaxed-interpolations");
+  let proxy = matches.value_of("proxy").unwrap_or("");
   let quiet = matches.is_present("quiet");
   let nanosec = matches.is_present("nanosec");
   let timeout = matches.value_of("timeout");
@@ -32,7 +33,7 @@ fn main() {
   #[cfg(windows)]
   let _ = control::set_virtual_terminal(true);
 
-  let benchmark_result = benchmark::execute(benchmark_file, report_path_option, relaxed_interpolations, no_check_certificate, quiet, nanosec, timeout, verbose);
+  let benchmark_result = benchmark::execute(benchmark_file, report_path_option, relaxed_interpolations, no_check_certificate, proxy, quiet, nanosec, timeout, verbose);
   let list_reports = benchmark_result.reports;
   let duration = benchmark_result.duration;
 
@@ -53,6 +54,7 @@ fn app_args<'a>() -> clap::ArgMatches<'a> {
     .arg(Arg::with_name("threshold").short("t").long("threshold").help("Sets a threshold value in ms amongst the compared file").takes_value(true).conflicts_with("report"))
     .arg(Arg::with_name("relaxed-interpolations").long("relaxed-interpolations").help("Do not panic if an interpolation is not present. (Not recommended)").takes_value(false))
     .arg(Arg::with_name("no-check-certificate").long("no-check-certificate").help("Disables SSL certification check. (Not recommended)").takes_value(false))
+    .arg(Arg::with_name("proxy").short("p").long("proxy").help("[protocol://]host[:port] Use this proxy").takes_value(true))
     .arg(Arg::with_name("quiet").short("q").long("quiet").help("Disables output").takes_value(false))
     .arg(Arg::with_name("timeout").short("o").long("timeout").help("Set timeout in seconds for all requests").takes_value(true))
     .arg(Arg::with_name("nanosec").short("n").long("nanosec").help("Shows statistics in nanoseconds").takes_value(false))


### PR DESCRIPTION
Adding a new command argument to be able to go through a proxy when
performing the benchmark test.