### PR TITLE
Add status code in response assignations

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,11 @@ plan:
     request:
       url: /api/users/{{ foo.body.manager_id }}
 
+  - name: Assert request response code
+    assert:
+      key: foo.status
+      value: 200
+
   - name: Assign values
     assign:
       key: bar

--- a/example/benchmark.yml
+++ b/example/benchmark.yml
@@ -55,6 +55,7 @@ plan:
       - 75
 
   - name: Fetch some users by hash
+    assign: fetchuser
     request:
       url: /api/users/{{ item.id }}
     shuffle: true
@@ -62,6 +63,11 @@ plan:
       - { id: 70 }
       - { id: 73 }
       - { id: 75 }
+
+  - name: Assert request response code
+    assert:
+      key: fetchuser.status
+      value: 200
 
   - name: Assert values
     assert:

--- a/src/actions/assert.rs
+++ b/src/actions/assert.rs
@@ -27,9 +27,9 @@ impl Assert {
     let value = extract(&item["assert"], "value");
 
     Assert {
-      name: name.to_string(),
-      key: key.to_string(),
-      value: value.to_string(),
+      name,
+      key,
+      value,
     }
   }
 }

--- a/src/actions/assign.rs
+++ b/src/actions/assign.rs
@@ -26,9 +26,9 @@ impl Assign {
     let value = extract(&item["assign"], "value");
 
     Assign {
-      name: name.to_string(),
-      key: key.to_string(),
-      value: value.to_string(),
+      name,
+      key,
+      value,
     }
   }
 }

--- a/src/actions/delay.rs
+++ b/src/actions/delay.rs
@@ -27,7 +27,7 @@ impl Delay {
     let seconds = u64::try_from(item["delay"]["seconds"].as_i64().unwrap()).expect("Invalid number of seconds");
 
     Delay {
-      name: name.to_string(),
+      name,
       seconds,
     }
   }

--- a/src/actions/exec.rs
+++ b/src/actions/exec.rs
@@ -28,9 +28,9 @@ impl Exec {
     let assign = extract_optional(item, "assign");
 
     Exec {
-      name: name.to_string(),
-      command: command.to_string(),
-      assign: assign.map(str::to_string),
+      name,
+      command,
+      assign,
     }
   }
 }

--- a/src/actions/mod.rs
+++ b/src/actions/mod.rs
@@ -42,9 +42,9 @@ impl fmt::Display for Report {
   }
 }
 
-pub fn extract_optional<'a>(item: &'a Yaml, attr: &'a str) -> Option<&'a str> {
+pub fn extract_optional<'a>(item: &'a Yaml, attr: &'a str) -> Option<String> {
   if let Some(s) = item[attr].as_str() {
-    Some(s)
+    Some(s.to_string())
   } else {
     if item[attr].as_hash().is_some() {
       panic!("`{}` needs to be a string. Try adding quotes", attr);
@@ -54,9 +54,11 @@ pub fn extract_optional<'a>(item: &'a Yaml, attr: &'a str) -> Option<&'a str> {
   }
 }
 
-pub fn extract<'a>(item: &'a Yaml, attr: &'a str) -> &'a str {
-  if let Some(s) = item[attr].as_str() {
-    s
+pub fn extract<'a>(item: &'a Yaml, attr: &'a str) -> String {
+  if let Some(s) = item[attr].as_i64() {
+    s.to_string()
+  } else if let Some(s) = item[attr].as_str() {
+    s.to_string()
   } else {
     if item[attr].as_hash().is_some() {
       panic!("`{}` is required needs to be a string. Try adding quotes", attr);

--- a/src/actions/request.rs
+++ b/src/actions/request.rs
@@ -38,6 +38,7 @@ pub struct Request {
 
 #[derive(Serialize, Deserialize)]
 struct AssignedRequest {
+  status: u16,
   body: Value,
   headers: Map<String, Value>,
 }
@@ -78,15 +79,15 @@ impl Request {
     }
 
     Request {
-      name: name.to_string(),
-      url: url.to_string(),
+      name,
+      url,
       time: 0.0,
       method,
       headers,
-      body: body.map(str::to_string),
+      body,
       with_item,
       index,
-      assign: assign.map(str::to_string),
+      assign,
     }
   }
 
@@ -274,10 +275,12 @@ impl Runnable for Request {
         status: 520u16,
       }),
       Some(response) => {
+        let status = response.status().as_u16();
+
         reports.push(Report {
           name: self.name.to_owned(),
           duration: duration_ms,
-          status: response.status().as_u16(),
+          status,
         });
 
         if response.cookies().count() > 0 {
@@ -302,6 +305,7 @@ impl Runnable for Request {
           let body: Value = serde_json::from_str(&data).unwrap_or(serde_json::Value::Null);
 
           let assigned = AssignedRequest {
+            status,
             body,
             headers,
           };


### PR DESCRIPTION
It is really interesting to hold the request status codes to be able to
interact with them. For example assertion but it can be nice for other
flow paths.