### PR TITLE
fix: increase maximum bounds of histogram

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -105,7 +105,7 @@ impl DrillStats {
 }
 
 fn compute_stats(sub_reports: &[Report]) -> DrillStats {
-  let mut hist = Histogram::<u64>::new_with_bounds(1, 60 * 60 * 1000, 2).unwrap();
+  let mut hist = Histogram::<u64>::new_with_bounds(1, 60 * 60 * 10000, 2).unwrap();
   let mut group_by_status = HashMap::new();
 
   for req in sub_reports {


### PR DESCRIPTION
Currently, the maximum bounds of `60*60*1000` is insufficient for requests that take longer than ~4000ms. Increasing the bounds of this by a factor of 10 should prevent this ever being an issue for long requests.