### PR TITLE
Fix millisecond conversions for Request

### DIFF
--- a/src/actions/mod.rs
+++ b/src/actions/mod.rs
@@ -26,19 +26,19 @@ pub trait Runnable {
 #[derive(Clone)]
 pub struct Report {
   pub name: String,
-  pub duration: f64,
+  pub duration_ms: f64,
   pub status: u16,
 }
 
 impl fmt::Debug for Report {
   fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-    write!(f, "\n- name: {}\n  duration: {}\n", self.name, self.duration)
+    write!(f, "\n- name: {}\n  duration: {}\n", self.name, self.duration_ms)
   }
 }
 
 impl fmt::Display for Report {
   fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-    write!(f, "\n- name: {}\n  duration: {}\n  status: {}\n", self.name, self.duration, self.status)
+    write!(f, "\n- name: {}\n  duration: {}\n  status: {}\n", self.name, self.duration_ms, self.status)
   }
 }
 

--- a/src/actions/request.rs
+++ b/src/actions/request.rs
@@ -272,7 +272,7 @@ impl Runnable for Request {
     match res {
       None => reports.push(Report {
         name: self.name.to_owned(),
-        duration: duration_ms,
+        duration_ms,
         status: 520u16,
       }),
       Some(response) => {
@@ -280,7 +280,7 @@ impl Runnable for Request {
 
         reports.push(Report {
           name: self.name.to_owned(),
-          duration: duration_ms,
+          duration_ms,
           status,
         });
 

--- a/src/checker.rs
+++ b/src/checker.rs
@@ -39,7 +39,7 @@ pub fn compare(list_reports: &[Vec<Report>], filepath: &str, threshold: &str) ->
   for report in list_reports {
     for (i, report_item) in report.iter().enumerate() {
       let recorded_duration = items[i]["duration"].as_f64().unwrap();
-      let delta_ms = report_item.duration - recorded_duration;
+      let delta_ms = report_item.duration_ms - recorded_duration;
 
       if delta_ms > threshold_value {
         println!("{:width$} is {}{} slower than before", report_item.name.green(), delta_ms.round().to_string().red(), "ms".red(), width = 25);

--- a/src/main.rs
+++ b/src/main.rs
@@ -90,17 +90,17 @@ struct DrillStats {
 }
 
 impl DrillStats {
-  fn mean_duration(&self) -> f64 {
-    self.hist.mean() / 1_000.0
+  fn mean_duration_ms(&self) -> f64 {
+    self.hist.mean()
   }
-  fn median_duration(&self) -> f64 {
-    self.hist.value_at_quantile(0.5) as f64 / 1_000.0
+  fn median_duration_ms(&self) -> f64 {
+    self.hist.value_at_quantile(0.5) as f64
   }
-  fn stdev_duration(&self) -> f64 {
-    self.hist.stdev() / 1_000.0
+  fn stdev_duration_ms(&self) -> f64 {
+    self.hist.stdev()
   }
-  fn value_at_quantile(&self, quantile: f64) -> f64 {
-    self.hist.value_at_quantile(quantile) as f64 / 1_000.0
+  fn value_at_quantile_ms(&self, quantile: f64) -> f64 {
+    self.hist.value_at_quantile(quantile) as f64
   }
 }
 
@@ -113,7 +113,7 @@ fn compute_stats(sub_reports: &[Report]) -> DrillStats {
   }
 
   for r in sub_reports.iter() {
-    hist += (r.duration * 1_000.0) as u64;
+    hist += r.duration_ms as u64;
   }
 
   let total_requests = sub_reports.len();
@@ -154,12 +154,12 @@ fn show_stats(list_reports: &[Vec<Report>], stats_option: bool, nanosec: bool, d
     println!("{:width$} {:width2$} {}", name.green(), "Total requests".yellow(), substats.total_requests.to_string().purple(), width = 25, width2 = 25);
     println!("{:width$} {:width2$} {}", name.green(), "Successful requests".yellow(), substats.successful_requests.to_string().purple(), width = 25, width2 = 25);
     println!("{:width$} {:width2$} {}", name.green(), "Failed requests".yellow(), substats.failed_requests.to_string().purple(), width = 25, width2 = 25);
-    println!("{:width$} {:width2$} {}", name.green(), "Median time per request".yellow(), format_time(substats.median_duration(), nanosec).purple(), width = 25, width2 = 25);
-    println!("{:width$} {:width2$} {}", name.green(), "Average time per request".yellow(), format_time(substats.mean_duration(), nanosec).purple(), width = 25, width2 = 25);
-    println!("{:width$} {:width2$} {}", name.green(), "Sample standard deviation".yellow(), format_time(substats.stdev_duration(), nanosec).purple(), width = 25, width2 = 25);
-    println!("{:width$} {:width2$} {}", name.green(), "99.0'th percentile".yellow(), format_time(substats.value_at_quantile(0.99), nanosec).purple(), width = 25, width2 = 25);
-    println!("{:width$} {:width2$} {}", name.green(), "99.5'th percentile".yellow(), format_time(substats.value_at_quantile(0.995), nanosec).purple(), width = 25, width2 = 25);
-    println!("{:width$} {:width2$} {}", name.green(), "99.9'th percentile".yellow(), format_time(substats.value_at_quantile(0.999), nanosec).purple(), width = 25, width2 = 25);
+    println!("{:width$} {:width2$} {}", name.green(), "Median time per request".yellow(), format_time(substats.median_duration_ms(), nanosec).purple(), width = 25, width2 = 25);
+    println!("{:width$} {:width2$} {}", name.green(), "Average time per request".yellow(), format_time(substats.mean_duration_ms(), nanosec).purple(), width = 25, width2 = 25);
+    println!("{:width$} {:width2$} {}", name.green(), "Sample standard deviation".yellow(), format_time(substats.stdev_duration_ms(), nanosec).purple(), width = 25, width2 = 25);
+    println!("{:width$} {:width2$} {}", name.green(), "99.0'th percentile".yellow(), format_time(substats.value_at_quantile_ms(0.99), nanosec).purple(), width = 25, width2 = 25);
+    println!("{:width$} {:width2$} {}", name.green(), "99.5'th percentile".yellow(), format_time(substats.value_at_quantile_ms(0.995), nanosec).purple(), width = 25, width2 = 25);
+    println!("{:width$} {:width2$} {}", name.green(), "99.9'th percentile".yellow(), format_time(substats.value_at_quantile_ms(0.999), nanosec).purple(), width = 25, width2 = 25);
   }
 
   // compute global stats
@@ -173,12 +173,12 @@ fn show_stats(list_reports: &[Vec<Report>], stats_option: bool, nanosec: bool, d
   println!("{:width2$} {}", "Successful requests".yellow(), global_stats.successful_requests.to_string().purple(), width2 = 25);
   println!("{:width2$} {}", "Failed requests".yellow(), global_stats.failed_requests.to_string().purple(), width2 = 25);
   println!("{:width2$} {} {}", "Requests per second".yellow(), format!("{:.2}", requests_per_second).purple(), "[#/sec]".purple(), width2 = 25);
-  println!("{:width2$} {}", "Median time per request".yellow(), format_time(global_stats.median_duration(), nanosec).purple(), width2 = 25);
-  println!("{:width2$} {}", "Average time per request".yellow(), format_time(global_stats.mean_duration(), nanosec).purple(), width2 = 25);
-  println!("{:width2$} {}", "Sample standard deviation".yellow(), format_time(global_stats.stdev_duration(), nanosec).purple(), width2 = 25);
-  println!("{:width2$} {}", "99.0'th percentile".yellow(), format_time(global_stats.value_at_quantile(0.99), nanosec).purple(), width2 = 25);
-  println!("{:width2$} {}", "99.5'th percentile".yellow(), format_time(global_stats.value_at_quantile(0.995), nanosec).purple(), width2 = 25);
-  println!("{:width2$} {}", "99.9'th percentile".yellow(), format_time(global_stats.value_at_quantile(0.999), nanosec).purple(), width2 = 25);
+  println!("{:width2$} {}", "Median time per request".yellow(), format_time(global_stats.median_duration_ms(), nanosec).purple(), width2 = 25);
+  println!("{:width2$} {}", "Average time per request".yellow(), format_time(global_stats.mean_duration_ms(), nanosec).purple(), width2 = 25);
+  println!("{:width2$} {}", "Sample standard deviation".yellow(), format_time(global_stats.stdev_duration_ms(), nanosec).purple(), width2 = 25);
+  println!("{:width2$} {}", "99.0'th percentile".yellow(), format_time(global_stats.value_at_quantile_ms(0.99), nanosec).purple(), width2 = 25);
+  println!("{:width2$} {}", "99.5'th percentile".yellow(), format_time(global_stats.value_at_quantile_ms(0.995), nanosec).purple(), width2 = 25);
+  println!("{:width2$} {}", "99.9'th percentile".yellow(), format_time(global_stats.value_at_quantile_ms(0.999), nanosec).purple(), width2 = 25);
 }
 
 fn compare_benchmark(list_reports: &[Vec<Report>], compare_path_option: Option<&str>, threshold_option: Option<&str>) {


### PR DESCRIPTION
This PR refactors `Request` and `Report` to use a field called `duration_ms` to avoid the extra multiplication by 1000 described in #165.

I chose to rename the field for clarity and to ensure that I'd accounted for all the places where it is used.

Closes #165