### PR TITLE
`pick` for `with items range`

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,6 +169,15 @@ plan:
       - 75
     shuffle: true
     pick: 1
+
+  - name: Three requests with random items from a range
+    request:
+      url: /api/users/{{ item }}
+    with_items_range:
+      start: 1
+      stop: 1000
+    shuffle: true
+    pick: 3
 ```
 
 As you can see, you can play with interpolations in different ways. This

--- a/SYNTAX.md
+++ b/SYNTAX.md
@@ -46,8 +46,10 @@ All those three items can be combined with `name` property to be show in logs.
 - `method`: HTTP method in the requests. Valid methods are GET, POST, PUT, PATCH, HEAD or DELETE. (default: GET)
 - `body`: Request body for methods like POST, PUT or PATCH.
 - `with_items`: List of items to be interpolated in the given request url.
-- `with_items_range`: Generates items from an iterator from start, step, stop.
+- `with_items_range`: Generates items from an iterator from start, step (optional, default: 1), stop.
 - `with_items_from_csv`: Read the given CSV values and go through all of them as items.
+- `shuffle`: Shuffle given items randomly (default: false).
+- `pick`: Number of items to pick and perform requests with.
 - `assign`: Save the response in the context to be interpolated later.
 - `tags`: List of tags for that item.
 

--- a/src/expandable/multi_iter_request.rs
+++ b/src/expandable/multi_iter_request.rs
@@ -1,3 +1,5 @@
+use std::convert::TryInto;
+
 use rand::seq::SliceRandom;
 use rand::thread_rng;
 use yaml_rust::Yaml;
@@ -54,6 +56,10 @@ pub fn expand(item: &Yaml, benchmark: &mut Benchmark) {
         }
       }
 
+      if let Some(pick) = item["pick"].as_i64() {
+        with_items.truncate(pick.try_into().expect("pick can't be larger than size of range"))
+      }
+
       for (index, value) in with_items.iter().enumerate() {
         let index = index as u32;
 
@@ -81,7 +87,6 @@ mod tests {
   }
 
   #[test]
-  #[should_panic]
   fn expand_multi_range_should_limit_requests_using_the_pick_option() {
     let text = "---\nname: foobar\nrequest:\n  url: /api/{{ item }}\npick: 3\nwith_items_range:\n  start: 2\n  step: 2\n  stop: 20";
     let docs = yaml_rust::YamlLoader::load_from_str(text).unwrap();

--- a/src/expandable/multi_iter_request.rs
+++ b/src/expandable/multi_iter_request.rs
@@ -82,6 +82,20 @@ mod tests {
 
   #[test]
   #[should_panic]
+  fn expand_multi_range_should_limit_requests_using_the_pick_option() {
+    let text = "---\nname: foobar\nrequest:\n  url: /api/{{ item }}\npick: 3\nwith_items_range:\n  start: 2\n  step: 2\n  stop: 20";
+    let docs = yaml_rust::YamlLoader::load_from_str(text).unwrap();
+    let doc = &docs[0];
+    let mut benchmark: Benchmark = Benchmark::new();
+
+    expand(doc, &mut benchmark);
+
+    assert!(is_that_you(doc));
+    assert_eq!(benchmark.len(), 3);
+  }
+
+  #[test]
+  #[should_panic]
   fn invalid_expand() {
     let text = "---\nname: foobar\nrequest:\n  url: /api/{{ item }}\nwith_items_range:\n  start: 1\n  step: 2\n  stop: foo";
     let docs = yaml_rust::YamlLoader::load_from_str(text).unwrap();


### PR DESCRIPTION
Closes: #171 

Should I update the examples in the readme or the syntax file?

I originally stumbled across this by following those and expecting it to just work.