### PR TITLE
fix: histogram upper bound is too low

### DIFF
--- a/src/benchmark.rs
+++ b/src/benchmark.rs
@@ -54,9 +54,12 @@ fn join<S: ToString>(l: Vec<S>, sep: &str) -> String {
   )
 }
 
+pub const DEFAULT_TIMEOUT_SECONDS: u64 = 10;
+pub const MAX_TIMEOUT_SECONDS: u64 = 120;
+
 #[allow(clippy::too_many_arguments)]
 pub fn execute(benchmark_path: &str, report_path_option: Option<&str>, relaxed_interpolations: bool, no_check_certificate: bool, quiet: bool, nanosec: bool, timeout: Option<&str>, verbose: bool, tags: &Tags) -> BenchmarkResult {
-  let config = Arc::new(Config::new(benchmark_path, relaxed_interpolations, no_check_certificate, quiet, nanosec, timeout.map_or(10, |t| t.parse().unwrap_or(10)), verbose));
+  let config = Arc::new(Config::new(benchmark_path, relaxed_interpolations, no_check_certificate, quiet, nanosec, timeout.map_or(DEFAULT_TIMEOUT_SECONDS, |t| t.parse().unwrap_or(DEFAULT_TIMEOUT_SECONDS).max(MAX_TIMEOUT_SECONDS)), verbose));
 
   if report_path_option.is_some() {
     println!("{}: {}. Ignoring {} and {} properties...", "Report mode".yellow(), "on".purple(), "concurrency".yellow(), "iterations".yellow());


### PR DESCRIPTION
(i believe this closes #151)

i was seeing panics happening when trying to print stats while load-testing a relatively inefficient, but not THAT inefficient site

did a bit of digging and realized the upper bound of the histogram implied an upper limit of 3.6s or 3600ms, which is obviously trivial to exceed when hitting any kind of relatively expensive API

it looks like the histogram initialization was just copy-pasta'd from the [example in the docs](https://docs.rs/hdrhistogram/latest/hdrhistogram/index.html#recording-samples):
![image](https://user-images.githubusercontent.com/15263431/225187666-b0515462-0077-4552-bda0-329362df5365.png)

however, in drill's case, it's actually measuring in microseconds, not milliseconds (and then divided down in all the stats, as evidenced by the fact that the request duration (already in ms) is being multiplied by 1000 before appending to the histogram:
![image](https://user-images.githubusercontent.com/15263431/225187873-f527a974-4b8a-439f-81fe-1e8efb337c8f.png)

as such I made two changes:
1. introduce a max timeout, so we can reasonably set an upper bound that should be impossible to ever exceed
2. convert the max timeout to microseconds and use that as the histogram's upper bound

if you're against the `MAX_TIMEOUT_SECONDS` constant that I introduced, I'm ok w dropping it but in that case, we either continue to risk panics _or_ we have to find a smarter way to derive the histogram's upper bound. we could base it on the actual timeout option, but the config is initialized inside of `benchmark::execute` & not returned back out, so it would require a more structural change in order to achieve this which I wanted to avoid in this PR

do let me know if there's a more preferrable solution to the issue, but hopefully this is at least a quick and dirty solution so that 3.6s+ requests don't cause drill to panic :3