### PR TITLE
mv main.rs to lib.rs

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,7 +17,7 @@ use linked_hash_map::LinkedHashMap;
 use std::collections::HashMap;
 use std::process;
 
-fn main() {
+pub fn main() {
   let matches = app_args();
   let benchmark_file = matches.value_of("benchmark").unwrap();
   let report_path_option = matches.value_of("report");

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,0 +1,4 @@
+
+fn main() {
+  drill::main();
+}


### PR DESCRIPTION
moved main.rs to lib.rs. (and make the main() pub)
replaced main.rs with a simple main() that calls drill:main().

Moving the code from main to lib.rs will be able to import the crate drill:: into tests and benchmarks.
Next, I will add a benchmark, keep this pr small and focus on the code move.