### PR TITLE
Don't overwrite old cookies on Set-Cookie

### DIFF
--- a/src/actions/request.rs
+++ b/src/actions/request.rs
@@ -284,14 +284,9 @@ impl Runnable for Request {
           status,
         });
 
-        if response.cookies().count() > 0 {
-          let mut cookies = Map::new();
-
-          for cookie in response.cookies() {
-            cookies.insert(cookie.name().to_string(), json!(cookie.value().to_string()));
-          }
-
-          context.insert("cookies".to_string(), json!(cookies));
+        for cookie in response.cookies() {
+          let cookies = context.entry("cookies").or_insert_with(|| json!({})).as_object_mut().unwrap();
+          cookies.insert(cookie.name().to_string(), json!(cookie.value().to_string()));
         }
 
         let data = if let Some(ref key) = self.assign {


### PR DESCRIPTION
Ran into an issue with cookies while trying this out:
- Request 1 would receive Set-Cookie headers for cookies A and B
- Request 2 would receive a Set-Cookie header for only cookie A
- On request 3, the iteration seemed to have forgotten cookie B

Turned out that the whole cookie object was getting replaced when handling each request.