### PR TITLE
Use 1 hour as histogram maximum instead of 3.6 seconds

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -105,7 +105,7 @@ impl DrillStats {
 }
 
 fn compute_stats(sub_reports: &[Report]) -> DrillStats {
-  let mut hist = Histogram::<u64>::new_with_bounds(1, 60 * 60 * 1000, 2).unwrap();
+  let mut hist = Histogram::<u64>::new_with_bounds(1, 60 * 60 * 1_000_000, 2).unwrap();
   let mut group_by_status = HashMap::new();
 
   for req in sub_reports {


### PR DESCRIPTION
I could make my server faster, but it's easier to send this PR. 😄 