### PR TITLE
Show max time per request in statistics

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -101,6 +101,9 @@ impl DrillStats {
   fn value_at_quantile(&self, quantile: f64) -> f64 {
     self.hist.value_at_quantile(quantile) as f64 / 1_000.0
   }
+  fn max_duration(&self) -> f64 {
+    self.hist.max() as f64 / 1_000.0
+  }
 }
 
 fn compute_stats(sub_reports: &[Report]) -> DrillStats {
@@ -159,6 +162,7 @@ fn show_stats(list_reports: &[Vec<Report>], stats_option: bool, nanosec: bool, d
     println!("{:width$} {:width2$} {}", name.green(), "99.0'th percentile".yellow(), format_time(substats.value_at_quantile(0.99), nanosec).purple(), width = 25, width2 = 25);
     println!("{:width$} {:width2$} {}", name.green(), "99.5'th percentile".yellow(), format_time(substats.value_at_quantile(0.995), nanosec).purple(), width = 25, width2 = 25);
     println!("{:width$} {:width2$} {}", name.green(), "99.9'th percentile".yellow(), format_time(substats.value_at_quantile(0.999), nanosec).purple(), width = 25, width2 = 25);
+    println!("{:width$} {:width2$} {}", name.green(), "Max time per request".yellow(), format_time(substats.max_duration(), nanosec).purple(), width = 25, width2 = 25);
   }
 
   // compute global stats
@@ -178,6 +182,7 @@ fn show_stats(list_reports: &[Vec<Report>], stats_option: bool, nanosec: bool, d
   println!("{:width2$} {}", "99.0'th percentile".yellow(), format_time(global_stats.value_at_quantile(0.99), nanosec).purple(), width2 = 25);
   println!("{:width2$} {}", "99.5'th percentile".yellow(), format_time(global_stats.value_at_quantile(0.995), nanosec).purple(), width2 = 25);
   println!("{:width2$} {}", "99.9'th percentile".yellow(), format_time(global_stats.value_at_quantile(0.999), nanosec).purple(), width2 = 25);
+  println!("{:width2$} {}", "Max time per request".yellow(), format_time(global_stats.max_duration(), nanosec).purple(), width2 = 25);
 }
 
 fn compare_benchmark(list_reports: &[Vec<Report>], compare_path_option: Option<&str>, threshold_option: Option<&str>) {


### PR DESCRIPTION
## Summary

Adds a **Max time per request** line to both the per-task and global statistics blocks. Previously the worst-case figure shown was the 99.9th percentile, which (as noted in #188) often is not enough to understand a system's tail behavior. The max is read straight from the existing `hdrhistogram` via `max()`, so there is no extra bookkeeping or memory cost.

## Example output

```
ping                      99.9'th percentile        477ms
ping                      Max time per request      477ms
...
99.9'th percentile        477ms
Max time per request      477ms
```

## Notes

- `cargo fmt --check`, `cargo clippy`, and `cargo build` all pass.
- Verified at runtime that the line renders in both the per-task and global blocks.

Closes #188

🤖 Generated with [Claude Code](https://claude.com/claude-code)