### PR TITLE
Stop tracking .claude local tooling directory

### DIFF
--- a/.claude/scheduled_tasks.lock
+++ b/.claude/scheduled_tasks.lock
@@ -1,1 +1,0 @@
-{"sessionId":"fd42e16f-2f44-4135-b3d6-f462f2a2f084","pid":3616,"procStart":"Sun May 31 18:11:38 2026","acquiredAt":1780251323583}

--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,6 @@ example/server/node_modules
 
 # Editor temp files
 .vscode
+
+# Claude Code local tooling
+.claude


### PR DESCRIPTION
## Summary

`.claude/scheduled_tasks.lock` was accidentally committed in #229 (a stray `git add -A`). It is local Claude Code tooling state, not part of drill.

- Untracks `.claude/scheduled_tasks.lock` (file kept locally, removed from the repo)
- Adds `.claude` to `.gitignore` so it can't be re-added

No source or build changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)