### PR TITLE
Resolve {{ index }} in a plain request (fixes #186)

### DIFF
--- a/src/benchmark.rs
+++ b/src/benchmark.rs
@@ -39,6 +39,8 @@ async fn run_iteration(benchmark: Arc<Benchmark>, pool: Pool, config: Arc<Config
 
   context.insert("iteration".to_string(), json!(iteration.to_string()));
   context.insert("base".to_string(), json!(config.base.to_string()));
+  // Default `index` to the iteration counter so `{{ index }}` resolves in a plain request; with_items expansions override it with the item position at execute time.
+  context.insert("index".to_string(), json!(iteration));
 
   for item in benchmark.iter() {
     item.execute(&mut context, &mut reports, &pool, &config).await;


### PR DESCRIPTION
## Problem (#186)

`{{ index }}` only existed inside `with_items` / `with_items_range` / `with_items_from_csv` / `with_items_from_file` expansions, where it is the item's position in the list. In a plain request the variable was never set, so a plan referencing `{{ index }}`:

- **panicked** in the default strict mode (`Unknown 'index' variable`), or
- interpolated to an **empty string** under `--relaxed-interpolations`.

## Fix

Seed `index` with the iteration counter when each iteration's context is built in `run_iteration`, so a plain request resolves `{{ index }}` to the iteration number. Expanded requests still override `index` with their list position at execute time, so `with_items` semantics are **unchanged**.

```
iterations: 3,      GET /idx/{{ index }}            -> /idx/0  /idx/1  /idx/2   (was: panic)
with_items:[a,b,c]  GET /{{ item }}/{{ index }}     -> /a/0  /b/1  /c/2         (unchanged)
```

## Notes

Minimal change (2 lines). Verified against the exact repro from #186 (previously panicked, now runs clean) and `cargo fmt` / `cargo clippy -- -D warnings` / `cargo test` (61) all pass.

Inspired by zoosky/driller#26, trimmed to just the core fix.
