### PR TITLE
Raise a helpful error for {{ index }} outside an items expansion (fixes #186)

### DIFF
--- a/SYNTAX.md
+++ b/SYNTAX.md
@@ -75,6 +75,15 @@ The `body` property can be specified in different ways depending on the type of 
 3. `body: { file: path/to/file.txt }`
   - This variant allows you to specify a file path, and the content of the file will be used as the request body.
 
+#### Built-in interpolation variables
+
+Besides anything you `assign`, a few variables are always available to `{{ }}` templates in URLs, headers and bodies:
+
+- `base`: the benchmark `base` URL.
+- `iteration`: the current iteration number (0-based).
+- `item`: the current item, only inside `with_items`, `with_items_range`, `with_items_from_csv` or `with_items_from_file` requests.
+- `index`: the position of the current item, only inside the `with_items*` requests above. Outside them it is **not** defined — use `iteration` for the current iteration number. Referencing `{{ index }}` where it is not available raises an error (or a warning under `--relaxed-interpolations`) suggesting `iteration`.
+
 #### tags item properties
 
 [Ansible](https://docs.ansible.com/ansible/latest/user_guide/playbooks_tags.html#special-tags-always-and-never)-like tags.

--- a/src/interpolator.rs
+++ b/src/interpolator.rs
@@ -40,11 +40,13 @@ impl<'a> Interpolator<'a> {
           return item;
         }
 
+        let message = unknown_variable_message(capture);
+
         if strict {
-          panic!("Unknown '{}' variable!", &capture);
+          panic!("{}", message);
         }
 
-        eprintln!("{} Unknown '{}' variable!", "WARNING!".yellow().bold(), &capture);
+        eprintln!("{} {}", "WARNING!".yellow().bold(), message);
 
         "".to_string()
       })
@@ -74,6 +76,16 @@ impl<'a> Interpolator<'a> {
       });
     }
     None
+  }
+}
+
+fn unknown_variable_message(variable: &str) -> String {
+  // `index` is only seeded inside with_items/range/csv/file expansions. When it
+  // is missing the user most likely wants the iteration counter, so point them there.
+  if variable == "index" {
+    "Unknown 'index' variable! It is only available inside 'with_items', 'with_items_range', 'with_items_from_csv' or 'with_items_from_file' requests. Use 'iteration' for the current iteration number.".to_string()
+  } else {
+    format!("Unknown '{variable}' variable!")
   }
 }
 
@@ -130,6 +142,15 @@ mod tests {
     let interpolator = Interpolator::new(&context);
     let url = String::from("/users/{{ userId }}");
     interpolator.resolve(&url, true);
+  }
+
+  #[test]
+  #[should_panic(expected = "Use 'iteration'")]
+  fn index_outside_expansion_suggests_iteration() {
+    let context: Context = Context::new();
+
+    let interpolator = Interpolator::new(&context);
+    interpolator.resolve("/users/{{ index }}", true);
   }
 
   #[test]


### PR DESCRIPTION
Fixes #186.

## Problem

`{{ index }}` is only seeded into the context inside `with_items`, `with_items_range`, `with_items_from_csv` and `with_items_from_file` requests, where it is the item's position in the list. Referencing it anywhere else (e.g. a plain request, or an `assert` on `index`) failed with a generic, unhelpful message:

- **panic** in the default strict mode: `Unknown 'index' variable!`
- a bare warning under `--relaxed-interpolations`

Neither gave any clue that `index` is scope-limited, and the user almost always actually wanted the iteration counter — which already exists as `iteration`.

## Fix

Rather than overloading `index` with a second meaning, detect this specific case and raise a dedicated message that explains the variable's scope and points to `iteration`:

```
Unknown 'index' variable! It is only available inside 'with_items',
'with_items_range', 'with_items_from_csv' or 'with_items_from_file' requests.
Use 'iteration' for the current iteration number.
```

The message is used both for the strict-mode panic and the relaxed-mode warning. `with_items*` requests are unaffected — `index` still resolves there as before.

## Docs

Documented the built-in interpolation variables (`base`, `iteration`, `item`, `index`) and `index`'s scope in `SYNTAX.md`.

## Verification

- Issue #186 repro now fails with the helpful message instead of `Unknown 'index' variable!`.
- A `with_items` request still resolves `{{ index }}` (e.g. `/a/0`, `/b/1`).
- Relaxed mode prints the helpful warning and continues.
- New unit test `index_outside_expansion_suggests_iteration`. `cargo fmt`, `cargo clippy -- -D warnings`, `cargo test` (62) all pass.
